### PR TITLE
Support repeat.vim

### DIFF
--- a/plugin/splitjoin.vim
+++ b/plugin/splitjoin.vim
@@ -13,8 +13,8 @@ endif
 " Public Interface:
 " =================
 
-command! SplitjoinSplit call s:Split()
-command! SplitjoinJoin  call s:Join()
+command! SplitjoinSplit call s:Split() | silent! call repeat#set(':SplitjoinSplit<cr>')
+command! SplitjoinJoin  call s:Join() | silent! call repeat#set(':SplitjoinJoin<cr>')
 
 " Internal Functions:
 " ===================


### PR DESCRIPTION
Hi Andrew,

I added support for [repeat.vim](http://www.vim.org/scripts/script.php?script_id=2136) which allow us to use dot '.' to repeat last join or split. I was editing a long html list item today, needed it so I made the addition. Hope someone else will find it useful, too.

Please test it and pull if you like.

Thanks!
