### PR TITLE
Fix repeat.vim call

### DIFF
--- a/plugin/splitjoin.vim
+++ b/plugin/splitjoin.vim
@@ -39,7 +39,7 @@ function! s:Split()
 
   for callback in b:splitjoin_split_callbacks
     if call(callback, []) != 0
-      silent! call repeat#set(':SplitjoinSplit<cr>')
+      silent! call repeat#set(":SplitjoinSplit\<cr>")
       break
     endif
   endfor
@@ -59,7 +59,7 @@ function! s:Join()
 
   for callback in b:splitjoin_join_callbacks
     if call(callback, []) != 0
-      silent! call repeat#set(':SplitjoinJoin<cr>')
+      silent! call repeat#set(":SplitjoinJoin\<cr>")
       break
     endif
   endfor


### PR DESCRIPTION
Hi Andrew,

This is a fix for the repeat#set() calls which stopped working for some reasons. I simply change the single quotes to double quotes.
