### PR TITLE
fix can't repeat if ':' map to something other key

### DIFF
--- a/plugin/splitjoin.vim
+++ b/plugin/splitjoin.vim
@@ -55,6 +55,9 @@ if g:splitjoin_split_mapping != ''
   exe 'nnoremap <silent> '.g:splitjoin_split_mapping.' :<c-u>call <SID>Mapping(g:splitjoin_split_mapping, "SplitjoinSplit")<cr>'
 endif
 
+nnoremap <silent> <plug>SplitjoinSplit  :<c-u>call <SID>Split()<cr>
+nnoremap <silent> <plug>SplitjoinJoin   :<c-u>call <SID>Join()<cr>
+
 " Internal Functions:
 " ===================
 
@@ -73,7 +76,7 @@ function! s:Split()
       call sj#PushCursor()
 
       if call(callback, [])
-        silent! call repeat#set(":SplitjoinSplit\<cr>")
+        silent! call repeat#set("\<plug>SplitjoinSplit")
         break
       endif
 
@@ -98,7 +101,7 @@ function! s:Join()
       call sj#PushCursor()
 
       if call(callback, [])
-        silent! call repeat#set(":SplitjoinJoin\<cr>")
+        silent! call repeat#set("\<plug>SplitjoinJoin")
         break
       endif
 


### PR DESCRIPTION
It can't be repeated if ':' map to something other key.
Because repeat.vim use feedkeys function for repeat and if ':' key map to another key, execute another key instead of ':'.

Like below

call feedkeys(":SplitjoinSplit<cr>")

':' execute as another key.
