### PR TITLE
Fix for incorrect behaviour for ruby block split/join

### DIFF
--- a/autoload/sj/ruby.vim
+++ b/autoload/sj/ruby.vim
@@ -285,7 +285,8 @@ endfunction
 function! sj#ruby#SplitBlock()
   let pattern = '\v\{(\s*\|.{-}\|)?\s*(.{-})\s*\}'
 
-  if sj#SearchUnderCursor('\v%(\k|\))\s*\zs'.pattern) <= 0
+
+  if sj#SearchUnderCursor('\v%(\k|!|\>|\?|\))\s*\zs'.pattern) <= 0
     return 0
   endif
 
@@ -299,8 +300,15 @@ function! sj#ruby#SplitBlock()
   endif
 
   let body = sj#GetMotion('Va{')
+  let multiline_block = 'do\1\n\2\nend'
+
+  normal! %
+  if search('\S\%#', 'Wbn')
+    let multiline_block = ' '.multiline_block
+  endif
+
   let body = join(split(body, '\s*;\s*'), "\n")
-  let replacement = substitute(body, '^'.pattern.'$', 'do\1\n\2\nend', '')
+  let replacement = substitute(body, '^'.pattern.'$', multiline_block, '')
 
   call sj#ReplaceMotion('Va{', replacement)
 

--- a/spec/plugin/ruby_spec.rb
+++ b/spec/plugin/ruby_spec.rb
@@ -431,6 +431,111 @@ describe "ruby" do
   end
 
   describe "blocks" do
+    it "splitjoins {}-blocks prepended by ?" do
+      set_file_contents <<-EOF
+        pens.any?{ |pen| pen.name.to_sym.in? names.flatten }
+      EOF
+
+      vim.search('to_sym')
+      split
+
+      assert_file_contents <<-EOF
+        pens.any? do |pen|
+          pen.name.to_sym.in? names.flatten
+        end
+      EOF
+
+      join
+
+      assert_file_contents <<-EOF
+        pens.any? { |pen| pen.name.to_sym.in? names.flatten }
+      EOF
+    end
+
+    it "splitjoins {}-blocks prepended by !" do
+      set_file_contents <<-EOF
+        pens.find!{ |pen| pen.name.to_sym.in? names.flatten }
+      EOF
+
+      vim.search('to_sym')
+      split
+
+      assert_file_contents <<-EOF
+        pens.find! do |pen|
+          pen.name.to_sym.in? names.flatten
+        end
+      EOF
+
+      join
+
+      assert_file_contents <<-EOF
+        pens.find! { |pen| pen.name.to_sym.in? names.flatten }
+      EOF
+    end
+
+    it "splitjoins {}-blocks prepended by -> ()" do
+      set_file_contents <<-EOF
+        -> (pen){ |pen| pen.name.to_sym.in? names.flatten }
+      EOF
+
+      vim.search('to_sym')
+      split
+
+      assert_file_contents <<-EOF
+       -> (pen) do |pen|
+         pen.name.to_sym.in? names.flatten
+       end
+      EOF
+
+      join
+
+      assert_file_contents <<-EOF
+        -> (pen) { |pen| pen.name.to_sym.in? names.flatten }
+      EOF
+    end
+
+    it "splitjoins {}-blocks prepended by ->" do
+      set_file_contents <<-EOF
+        -> { |pen| pen.name.to_sym.in? names.flatten }
+      EOF
+
+      vim.search('to_sym')
+      split
+
+      assert_file_contents <<-EOF
+       -> do |pen|
+         pen.name.to_sym.in? names.flatten
+       end
+      EOF
+
+      join
+
+      assert_file_contents <<-EOF
+        -> { |pen| pen.name.to_sym.in? names.flatten }
+      EOF
+    end
+
+    it "splitjoins {}-blocks without leading whitespace" do
+      set_file_contents <<-EOF
+        Bar.new{ |b| puts b.to_s }
+      EOF
+
+      vim.search('puts')
+      split
+
+      assert_file_contents <<-EOF
+        Bar.new do |b|
+          puts b.to_s
+        end
+      EOF
+
+      join
+
+      assert_file_contents <<-EOF
+        Bar.new { |b| puts b.to_s }
+      EOF
+    end
+
     it "splitjoins {}-blocks with arguments and do-end blocks" do
       set_file_contents <<-EOF
         Bar.new { |b| puts b.to_s }


### PR DESCRIPTION
It fixes following corner cases:
- block without surrounding spaces
- block prepended by `#method?`, `#method!` lambda `->` definition
