### PR TITLE
Make specs rspec3 compliant

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'http://rubygems.org'
 
 gem 'rake'
-gem 'rspec', '~> 2.14.0'
+gem 'rspec'
 gem 'vimrunner', '0.3.0'
 gem 'pry'
 

--- a/spec/support/vim.rb
+++ b/spec/support/vim.rb
@@ -17,7 +17,7 @@ module Support
 
     def assert_file_contents(string)
       string = normalize_string_indent(string)
-      IO.read(filename).strip.should eq string
+      expect(IO.read(filename).strip).to eq(string)
     end
   end
 end


### PR DESCRIPTION
rspec3 deprecated is the `should` syntax - they try to enforce `expect` now.

``` ruby
expect(IO.read(filename).strip).to eq(string)
```

This also works with rspec 2.x - so we can remove setting rspec to a fixed version in the `Gemfile` again.
