### PR TITLE
PHP: allow splitting braced expressions (argument lists, #43)

### DIFF
--- a/autoload/sj/php.vim
+++ b/autoload/sj/php.vim
@@ -1,8 +1,8 @@
-function! sj#php#SplitArray()
-  let arraypattern = '\(array\)\s*(\(.*\))'
+function! sj#php#SplitBraces()
+  let bracedpattern = '(\(.*\))'
   let line         = getline('.')
 
-  if line !~? arraypattern
+  if line !~? bracedpattern
     return 0
   else
     let [from, to] = sj#LocateBracesOnLine('(', ')')
@@ -30,14 +30,14 @@ function! sj#php#SplitArray()
   endif
 endfunction
 
-function! sj#php#JoinArray()
+function! sj#php#JoinBraces()
   let line = getline('.')
 
-  if line !~ 'array(\s*$'
+  if line !~ '(\s*$'
     return 0
   endif
 
-  call search('array(\s*$', 'ce', line('.'))
+  call search('(\s*$', 'ce', line('.'))
 
   let body = sj#GetMotion('Vi(')
 

--- a/ftplugin/php/splitjoin.vim
+++ b/ftplugin/php/splitjoin.vim
@@ -1,6 +1,6 @@
 let b:splitjoin_split_callbacks = [
       \ 'sj#js#SplitArray',
-      \ 'sj#php#SplitArray',
+      \ 'sj#php#SplitBraces',
       \ 'sj#php#SplitIfClause',
       \ 'sj#html#SplitTags',
       \ 'sj#php#SplitPhpMarker',
@@ -9,7 +9,7 @@ let b:splitjoin_split_callbacks = [
 let b:splitjoin_join_callbacks = [
       \ 'sj#php#JoinPhpMarker',
       \ 'sj#js#JoinArray',
-      \ 'sj#php#JoinArray',
+      \ 'sj#php#JoinBraces',
       \ 'sj#php#JoinIfClause',
       \ 'sj#php#JoinHtmlTags',
       \ ]


### PR DESCRIPTION
Dead simple change to allow spliting argument lists (and pretty much everything braced including `for`, `while`, `if`, etc...). Discussed in #43 .