### PR TITLE
First pass C# support by piggybacking on C support

### DIFF
--- a/ftplugin/cs/splitjoin.vim
+++ b/ftplugin/cs/splitjoin.vim
@@ -1,0 +1,15 @@
+" Use C syntax for C# for now
+
+if !exists('b:splitjoin_split_callbacks')
+  let b:splitjoin_split_callbacks = [
+        \ 'sj#c#SplitIfClause',
+        \ 'sj#c#SplitFuncall',
+        \ ]
+endif
+
+if !exists('b:splitjoin_join_callbacks')
+  let b:splitjoin_join_callbacks = [
+        \ 'sj#c#JoinFuncall',
+        \ 'sj#c#JoinIfClause',
+        \ ]
+endif


### PR DESCRIPTION
I do not know whether C support will work 100% for C# but it works for
what I want (function parameters) and it is better than not supporting
it at all. If there does turn out to be divergence between C and C# then
C# should probably not piggyback on C support anymore, but for now I
don't see any harm in it.