### PR TITLE
[WIP] Support for graphviz dot

### DIFF
--- a/autoload/sj/dot.vim
+++ b/autoload/sj/dot.vim
@@ -135,6 +135,7 @@ endfunction
 function! sj#dot#JoinStatement()
   " TODO guard for comments etc
   normal! J
+  return 1
 endfunction
 
 function! sj#dot#SplitChainedEdge()
@@ -148,6 +149,7 @@ function! sj#dot#SplitChainedEdge()
 endfunction
 
 function! sj#dot#JoinChainedEdge()
+  " TODO initial guard 
   let edges = s:ParseConsecutiveLines()
   let edges = s:ChainTransitiveEdges(edges)
   if len(edges) > 1 | return 0 | endif

--- a/autoload/sj/dot.vim
+++ b/autoload/sj/dot.vim
@@ -1,0 +1,39 @@
+let s:edge = '->'
+let s:node = '\("*[^\"]\{-}"\|\i\+\)'
+
+function! sj#dot#SplitEdges()
+  " if sj#SearchUnderCursor('[.\{-}]', '') <= 0
+  "   " No split if line contains []
+  "   " Just a rough guess to use this function
+  "   echom "WARNING"
+  "   return 0
+  " endif
+  let line = getline('.')
+  if line !~ s:edge
+    return 0
+  endif
+  let sides = split(getline('.'), s:edge) 
+  let lhs = split(get(sides, 0, ''), ',') 
+  let rhs = split(get(sides, 1, ''), ',') 
+  if len(lhs) < 2 && len(rhs) < 2
+    return 0
+  endif
+  let edges = []
+  for source_node in lhs
+    for dest_node in rhs
+      " TODO more beautiful trimming and readding of spaces here
+      let edges += [source_node . s:edge . dest_node]
+    endfor
+  endfor
+  let body = join(edges, "\n")
+  call sj#ReplaceMotion('V', body)
+  return 1
+endfunction
+
+function! sj#dot#JoinEdges()
+  " if sj#SearchUnderCursor('[.\{-}]', '') <= 0
+  "   return 0
+  " endif
+  return 1
+
+endfunction

--- a/autoload/sj/dot.vim
+++ b/autoload/sj/dot.vim
@@ -12,17 +12,23 @@ function! sj#dot#SplitEdges()
   if line !~ s:edge
     return 0
   endif
-  let sides = split(getline('.'), s:edge) 
-  let lhs = split(get(sides, 0, ''), ',') 
-  let rhs = split(get(sides, 1, ''), ',') 
+  let statements = split(line, ';')
+  " Use last statement of a line as heuristic
+  " in case there are mor than one
+  let sides = split(statements[-1], s:edge) 
+
+  " FIXME will fail on \" , \"
+  let lhs = sj#TrimList(split(get(sides, 0, ''), ','))
+  let rhs = sj#TrimList(split(get(sides, 1, ''), ','))
+
   if len(lhs) < 2 && len(rhs) < 2
+    " nothing to do here: A -> B; or incomplete
     return 0
   endif
   let edges = []
   for source_node in lhs
     for dest_node in rhs
-      " TODO more beautiful trimming and readding of spaces here
-      let edges += [source_node . s:edge . dest_node]
+      let edges += [source_node . ' ' . s:edge . ' ' . dest_node . ';']
     endfor
   endfor
   let body = join(edges, "\n")
@@ -30,10 +36,33 @@ function! sj#dot#SplitEdges()
   return 1
 endfunction
 
+function! sj#dot#CompleteMatching(edges)
+  " edges should be [src, dst] pairs
+  " srcs, dsts = unzip(edges)
+  matching = {}
+  let all_dest_nodes = []
+  for edge in edges
+    let [source_node, dest_node] = edge
+    matching[source_node] += [dest_node]
+    let all_dest_nodes += [dest_node]
+  endfor
+  for dest_nodes in values(matching)
+    " FIXME pseudocode, we actually need set equality
+    if dest_nodes != all_dest_nodes
+      return 0
+    endif
+  endfor
+  return 1
+endfunction
+
 function! sj#dot#JoinEdges()
   " if sj#SearchUnderCursor('[.\{-}]', '') <= 0
   "   return 0
   " endif
+  call sj#PushCursor()
+
+
+  call sj#PopCursor()
   return 1
 
 endfunction

--- a/autoload/sj/dot.vim
+++ b/autoload/sj/dot.vim
@@ -4,7 +4,8 @@ let s:node = '\("*[^\"]\{-}"\|\i\+\)'
 function! sj#dot#ExtractNodes(side)
   " Just split on comma
   " FIXME will fail on \" , \"
-  return sj#TrimList(split(side, ','))
+  let nodes = split(a:side, ',')
+  return sj#TrimList(nodes)
 endfunction
 
 function! sj#dot#SplitEdges()

--- a/autoload/sj/dot.vim
+++ b/autoload/sj/dot.vim
@@ -98,6 +98,7 @@ function! s:MergeEdges(edges)
 endfunction
 
 function! s:ChainTransitiveEdges(edges)
+  " FIXME BUG IN HERE
   let edges = copy(a:edges)
   let finished = 0
   while !finished
@@ -110,12 +111,10 @@ function! s:ChainTransitiveEdges(edges)
           " FIXME
           let edges[idx] += [edges[jdx][-1]]
           let finished = 0
-        endif
-        if !finished
           unlet edges[jdx]
-        else
-          let jdx += 1
+          break
         endif
+        let jdx += 1
       endwhile
       let idx += 1
     endwhile
@@ -134,8 +133,8 @@ function! sj#dot#SplitStatement()
 endfunction
 
 function! sj#dot#JoinStatement()
-  " unused
-  join
+  " TODO guard for comments etc
+  normal! J
 endfunction
 
 function! sj#dot#SplitChainedEdge()
@@ -179,10 +178,14 @@ function! sj#dot#SplitMultiEdge()
 endfunction
 
 function! sj#dot#JoinMultiEdge()
+  " TODO guard for comments or blank lines
+  " Check whether two lines are 
   let edges = s:ParseConsecutiveLines()
+  if len(edges) < 2 | return 0 | endif
   let edges = s:MergeEdges(edges)
   if len(edges) > 1 | return 0 | endif
   call sj#ReplaceMotion('Vj', s:Edge2string(edges[0]))
+  echom "Joined Multi-edge"
   return 1
 endfunction
 " }}}

--- a/ftplugin/dot/splitjoin.vim
+++ b/ftplugin/dot/splitjoin.vim
@@ -1,0 +1,11 @@
+if !exists('b:splitjoin_split_callbacks')
+  let b:splitjoin_split_callbacks = [
+        \ 'sj#dot#SplitEdges'
+        \ ]
+endif
+
+if !exists('b:splitjoin_join_callbacks')
+  let b:splitjoin_join_callbacks = [
+        \ 'sj#dot#JoinEdges'
+        \ ]
+endif

--- a/ftplugin/dot/splitjoin.vim
+++ b/ftplugin/dot/splitjoin.vim
@@ -1,13 +1,15 @@
 if !exists('b:splitjoin_split_callbacks')
   let b:splitjoin_split_callbacks = [
         \ 'sj#dot#SplitStatement',
-        \ 'sj#dot#SplitEdge'
+        \ 'sj#dot#SplitChainedEdge',
+        \ 'sj#dot#SplitMultiEdge'
         \ ]
 endif
 
 if !exists('b:splitjoin_join_callbacks')
   let b:splitjoin_join_callbacks = [
-        \ 'sj#dot#JoinEdge',
+        \ 'sj#dot#JoinMultiEdge',
+        \ 'sj#dot#JoinChainedEdge',
         \ 'sj#dot#JoinStatement'
         \ ]
 endif

--- a/ftplugin/dot/splitjoin.vim
+++ b/ftplugin/dot/splitjoin.vim
@@ -1,11 +1,13 @@
 if !exists('b:splitjoin_split_callbacks')
   let b:splitjoin_split_callbacks = [
-        \ 'sj#dot#SplitEdges'
+        \ 'sj#dot#SplitStatement',
+        \ 'sj#dot#SplitEdge'
         \ ]
 endif
 
 if !exists('b:splitjoin_join_callbacks')
   let b:splitjoin_join_callbacks = [
-        \ 'sj#dot#JoinEdges'
+        \ 'sj#dot#JoinEdge',
+        \ 'sj#dot#JoinStatement'
         \ ]
 endif


### PR DESCRIPTION
Hey @AndrewRadev 
This is my initial version for graphviz dot support. While it works as intended for nodes that are variables (in most cases this holds), it lacks robustness against string node names which contain special characters. For instance, I started with `split(statement, ';')` instead of using proper regular expressions.
Two examples:

```dot
[aABceFs]  1+ ~/.v/p/t/s/s/a/sj                                                                                                                                                                                    
// Example 1
// Cursor on 'A'

A, B -> C -> D -> E; X -> Y;

// gS

A, B -> C -> D -> E;
X -> Y;

// gS

A, B -> C;
C -> D;
D -> E;
X -> Y;

// gS

A -> C;
B -> C;
C -> D;
D -> E;
X -> Y;

// gJ

A, B -> C;
C -> D;
D -> E;
X -> Y;

// gJ

A, B -> C -> D;
D -> E;
X -> Y;

// gJ

A, B -> C -> D -> E;
X -> Y;

// gJ

A, B -> C -> D -> E; X -> Y;


// Example 2
// Cursor on 'A'

A, B -> C, D;

// gS

A -> C;
A -> D;
B -> C;
B -> D;

// gJ

A -> C, D;
B -> C;
B -> D;

// jgJ

A -> C, D;
B -> C, D;

// kgJ

A, B -> C, D;

```