### PR TITLE
Add support for golang func definition and func calls

### DIFF
--- a/autoload/sj/go.vim
+++ b/autoload/sj/go.vim
@@ -52,9 +52,62 @@ function! sj#go#SplitStruct()
 endfunction
 
 function! sj#go#JoinStruct()
+  return s:joinStructOrFunc('{', '}')
+endfunction
+
+function! sj#go#SplitFunc()
+  let line = getline('.')
+  if line !~ '^func '
+    return 0
+  endif
+
+  let [start, end] = s:locateFuncBracesOnLine(line)
+  if start < 0 && end < 0
+    return 0
+  endif
+
+  let parsed = sj#ParseJsonObjectBody(start + 1, end - 1)
+
+  let arg_groups = []
+  let typed_arg_group = ''
+  for elem in parsed
+    if match(elem, '\s\+') != -1
+      let typed_arg_group .= elem
+      call add(arg_groups, typed_arg_group)
+      let typed_arg_group = ''
+    else
+      " not typed here, add to group
+      let typed_arg_group .= elem . ', '
+    endif
+  endfor
+
+  call sj#ReplaceCols(start + 1, end - 1, "\n".join(arg_groups, ",\n").",\n")
+  return 1
+endfunction
+
+function! sj#go#JoinFunc()
+  return s:joinStructOrFunc('(', ')')
+endfunction
+
+function! sj#go#SplitFuncCall()
+  let [start, end] = sj#LocateBracesOnLine('(', ')', ['goString', 'goComment'])
+  if start < 0 && end < 0
+    return 0
+  endif
+
+  let args = sj#ParseJsonObjectBody(start + 1, end - 1)
+  call sj#ReplaceCols(start + 1, end - 1, "\n".join(args, ",\n").",\n")
+  return 1
+endfunction
+
+function! sj#go#JoinFuncCall()
+  return s:joinStructOrFunc('(', ')')
+endfunction
+
+function! s:joinStructOrFunc(openBrace, closeBrace)
   let start_lineno = line('.')
 
-  if search('{$', 'Wc', line('.')) <= 0
+  if search(a:openBrace.'$', 'Wc', line('.')) <= 0
     return 0
   endif
 
@@ -73,6 +126,30 @@ function! sj#go#JoinStruct()
     call add(arguments, argument)
   endfor
 
-  call sj#ReplaceMotion('va{', '{'.join(arguments, ', ').'}')
+  call sj#ReplaceMotion('va'.a:openBrace, a:openBrace . join(arguments, ', ') . a:closeBrace)
   return 1
+endfunction
+
+" Find start and end positions of braces which contains argument list.
+" This handles nested braces introduced by func types (see go_spec.rb).
+function! s:locateFuncBracesOnLine(line)
+  let receiver_pat = '\s\+([^)]*)'
+  let arg_open_brace_pat = '^func\('.receiver_pat.'\|\)\s\+\w\+(\zs\ze'
+  let start = match(a:line, arg_open_brace_pat)
+  let braces = 1
+  let i = start
+  while i < strlen(a:line) && braces > 0
+    if a:line[i] == '('
+      let braces += 1
+    elseif a:line[i] == ')'
+      let braces -= 1
+    endif
+    let i += 1
+  endwhile
+
+  if braces > 0
+    return [-1, -1]
+  endif
+
+  return [start, i]
 endfunction

--- a/ftplugin/go/splitjoin.vim
+++ b/ftplugin/go/splitjoin.vim
@@ -2,10 +2,14 @@ let b:splitjoin_split_callbacks = [
       \ 'sj#go#SplitImports',
       \ 'sj#go#SplitVars',
       \ 'sj#go#SplitStruct',
+      \ 'sj#go#SplitFunc',
+      \ 'sj#go#SplitFuncCall',
       \ ]
 
 let b:splitjoin_join_callbacks = [
       \ 'sj#go#JoinImports',
       \ 'sj#go#JoinVars',
       \ 'sj#go#JoinStruct',
+      \ 'sj#go#JoinFunc',
+      \ 'sj#go#JoinFuncCall',
       \ ]

--- a/spec/plugin/go_spec.rb
+++ b/spec/plugin/go_spec.rb
@@ -106,4 +106,134 @@ describe "go" do
       StructType{one: 1, two: "asdf", three: []int{1, 2, 3}}
     EOF
   end
+
+  describe "funcs" do
+    def assert_split_join(initial, split_expected, join_expected)
+      set_file_contents initial
+      setup_go_filetype
+      split
+      # In case there is no Go installed, deindent everything:
+      vim.normal '9<<9<<9<<9<<'
+      vim.write
+      assert_file_contents split_expected
+      join
+      assert_file_contents join_expected
+    end
+
+    it "handles function definitions" do
+      initial = <<-EOF
+        func Func(a, b int, c time.Time, d func(int) error, e func(int, int) (int, error), f ...time.Time) {
+        }
+      EOF
+      split = <<-EOF
+        func Func(
+        a, b int,
+        c time.Time,
+        d func(int) error,
+        e func(int, int) (int, error),
+        f ...time.Time,
+        ) {
+        }
+      EOF
+      joined = <<-EOF
+        func Func(a, b int, c time.Time, d func(int) error, e func(int, int) (int, error), f ...time.Time) {
+        }
+      EOF
+      assert_split_join(initial, split, joined)
+    end
+
+    it "handles function definitions with return types" do
+      initial = <<-EOF
+        func Func(a, b int, c time.Time, d func(int) error, e func(int, int) (int, error), f ...time.Time) (r string, err error) {
+        }
+      EOF
+      split = <<-EOF
+        func Func(
+        a, b int,
+        c time.Time,
+        d func(int) error,
+        e func(int, int) (int, error),
+        f ...time.Time,
+        ) (r string, err error) {
+        }
+      EOF
+      joined = <<-EOF
+        func Func(a, b int, c time.Time, d func(int) error, e func(int, int) (int, error), f ...time.Time) (r string, err error) {
+        }
+      EOF
+      assert_split_join(initial, split, joined)
+    end
+
+    it "handles method definitions" do
+      initial = <<-EOF
+        func (r Receiver) Method(a, b int, c time.Time, d func(int) error, e func(int, int) (int, error), f ...time.Time) {
+        }
+      EOF
+      split = <<-EOF
+        func (r Receiver) Method(
+        a, b int,
+        c time.Time,
+        d func(int) error,
+        e func(int, int) (int, error),
+        f ...time.Time,
+        ) {
+        }
+      EOF
+      joined = <<-EOF
+        func (r Receiver) Method(a, b int, c time.Time, d func(int) error, e func(int, int) (int, error), f ...time.Time) {
+        }
+      EOF
+      assert_split_join(initial, split, joined)
+    end
+
+    it "handles method definitions with return types" do
+      initial = <<-EOF
+        func (r Receiver) Method(a, b int, c time.Time, d func(int) error, e func(int, int) (int, error), f ...time.Time) (r string, err error) {
+        }
+      EOF
+      split = <<-EOF
+        func (r Receiver) Method(
+        a, b int,
+        c time.Time,
+        d func(int) error,
+        e func(int, int) (int, error),
+        f ...time.Time,
+        ) (r string, err error) {
+        }
+      EOF
+      joined = <<-EOF
+        func (r Receiver) Method(a, b int, c time.Time, d func(int) error, e func(int, int) (int, error), f ...time.Time) (r string, err error) {
+        }
+      EOF
+      assert_split_join(initial, split, joined)
+    end
+  end
+
+  specify "func calls" do
+    set_file_contents <<-EOF
+      err := Func(a, b, c, d)
+    EOF
+    setup_go_filetype
+
+    split
+
+    # In case there is no Go installed, deindent everything:
+    vim.normal '6<<6<<6<<6<<6<<'
+    vim.write
+
+    assert_file_contents <<-EOF
+      err := Func(
+      a,
+      b,
+      c,
+      d,
+      )
+    EOF
+
+    join
+
+    assert_file_contents <<-EOF
+      err := Func(a, b, c, d)
+    EOF
+  end
 end


### PR DESCRIPTION
Hi, I've added a feature for splitting/joining golang func definitions and func calls.
I've been using this myself for a week or so, and seems to be working properly.

This is a superset of #107, which adds splitting/joining of func calls.
This PR also includes test cases.
(only after I wrote this I realized there's already a similar PR, sorry!)

Let me know if there's something I can improve.
Thanks!