### PR TITLE
fix disappearing hash bug

### DIFF
--- a/autoload/sj/argparser/ruby.vim
+++ b/autoload/sj/argparser/ruby.vim
@@ -1,11 +1,13 @@
 " Constructor:
 " ============
 
-function! sj#argparser#ruby#Construct(start_index, end_index, line)
+function! sj#argparser#ruby#Construct(start_index, end_index, line, ...)
+  let should_expand_option_hash = (a:0 > 0) ? a:1 : 1
   let parser = sj#argparser#common#Construct(a:start_index, a:end_index, a:line)
 
   call extend(parser, {
         \ 'hash_type': '',
+        \ 'should_expand_option_hash': should_expand_option_hash,
         \
         \ 'Process':          function('sj#argparser#ruby#Process'),
         \ 'PushArg':          function('sj#argparser#ruby#PushArg'),
@@ -63,7 +65,9 @@ function! sj#argparser#ruby#Process() dict
   if len(self.current_arg) > 0
     call self.PushArg()
   endif
-  call self.ExpandOptionHash()
+  if self.should_expand_option_hash
+    call self.ExpandOptionHash()
+  endif
 endfunction
 
 " Pushes the current argument either to the args or opts stack and initializes
@@ -174,8 +178,10 @@ function! sj#argparser#ruby#LocateHash()
   return sj#LocateBracesOnLine('{', '}', ['rubyInterpolationDelimiter', 'rubyString'])
 endfunction
 
-function! sj#argparser#ruby#ParseArguments(start_index, end_index, line)
-  let parser = sj#argparser#ruby#Construct(a:start_index, a:end_index, a:line)
+function! sj#argparser#ruby#ParseArguments(start_index, end_index, line, ...)
+  let should_expand_option_hash = (a:0 > 0) ? a:1 : 1
+  let parser = sj#argparser#ruby#Construct(
+        \ a:start_index, a:end_index, a:line, should_expand_option_hash)
   call parser.Process()
   return [ a:start_index, parser.index, parser.args, parser.opts, parser.hash_type ]
 endfunction

--- a/autoload/sj/ruby.vim
+++ b/autoload/sj/ruby.vim
@@ -598,7 +598,8 @@ function! sj#ruby#SplitArray()
     return 0
   endif
 
-  let [from, to, args; _rest] = sj#argparser#ruby#ParseArguments(from + 1, to - 1, getline('.'))
+  let [from, to, args; _rest] = sj#argparser#ruby#ParseArguments(
+        \ from + 1, to - 1, getline('.'), 0)
   if from < 0
     return 0
   endif

--- a/spec/plugin/ruby_spec.rb
+++ b/spec/plugin/ruby_spec.rb
@@ -1082,6 +1082,25 @@ describe "ruby" do
         end
       EOF
     end
+
+    specify "last hash inside array doesn't disappear" do
+      set_file_contents "array = [0, { a: 1 }]"
+
+      vim.search '0'
+      split
+
+      assert_file_contents <<-EOF
+        array = [
+          0,
+          { a: 1 }
+        ]
+      EOF
+
+      vim.search 'array ='
+      join
+
+      assert_file_contents "array = [0, { a: 1 }]"
+    end
   end
 
   describe "string array literals" do


### PR DESCRIPTION
tl;dr; Split this
```ruby
a = [0, { b: 1 }]
```
you get this:
```ruby
a = [
  0
]
```

Notice that the last element in array disappeared.

### Problem

__sj#argparser#ruby#Process()__ calls __self.ExpandOptionHash()__, so the last argument is being parsed and moved from __self.args__ to __self.ops__. __sj#ruby#SplitArray()__ later ignores the options.

### Solution

Skip __self.ExpandOptionHash()__ call if splitting array.