### PR TITLE
Add vue support.

### DIFF
--- a/ftplugin/vue/splitjoin.vim
+++ b/ftplugin/vue/splitjoin.vim
@@ -1,0 +1,25 @@
+let b:splitjoin_split_callbacks = [
+      \ 'sj#html#SplitTags',
+      \ 'sj#html#SplitAttributes',
+      \ 'sj#css#SplitDefinition',
+      \ 'sj#css#SplitMultilineSelector',
+      \ 'sj#js#SplitFatArrowFunction',
+      \ 'sj#js#SplitArray',
+      \ 'sj#js#SplitObjectLiteral',
+      \ 'sj#js#SplitFunction',
+      \ 'sj#js#SplitOneLineIf',
+      \ 'sj#js#SplitArgs'
+      \ ]
+
+let b:splitjoin_join_callbacks = [
+      \ 'sj#html#JoinAttributes',
+      \ 'sj#html#JoinTags',
+      \ 'sj#css#JoinDefinition',
+      \ 'sj#css#JoinMultilineSelector',
+      \ 'sj#js#JoinFatArrowFunction',
+      \ 'sj#js#JoinArray',
+      \ 'sj#js#JoinArgs',
+      \ 'sj#js#JoinFunction',
+      \ 'sj#js#JoinOneLineIf',
+      \ 'sj#js#JoinObjectLiteral',
+\ ]


### PR DESCRIPTION
Vuejs components are a single file containing css, js and html. Not sure if this is the proper way to do things, but it seems to work for me.

Alternatively, maybe it would be possible to add syntax region support for `splitjoin.vim`? I'm not sure if it's possible at all, but that way we could have each region use the correct splits/joins (I noticed join won't work in a <script> tag region inside a .html file for example).