### PR TITLE
Use `\k`, not `\w`, for splitting `qw(...)` constructs

### DIFF
--- a/autoload/sj/perl.vim
+++ b/autoload/sj/perl.vim
@@ -162,7 +162,7 @@ function! sj#perl#SplitWordList()
     return 0
   endif
 
-  let items = split(matchstr(remainder_of_line, '\%(\w\|\s\)\+'), '\s\+')
+  let items = split(matchstr(remainder_of_line, '\%(\k\|\s\)\+'), '\s\+')
   let body  = "(\n".join(items, "\n")."\n)"
   call sj#ReplaceMotion('Va(', body)
 


### PR DESCRIPTION
This is a tiny change -- the regex is insufficient, as Perl recognizes
more than the class of characters represented by `\w`, e.g. ":".  With
just `\w`, something like this is, ah, sub-optimally split:

    qw( MooseX::StrictConstructor::Trait::Class MooseX::TraitFor::Meta::Class::BetterAnonClassNames )

`\k` should suffice, as `iskeyword` will contain the additional
characters.