### PR TITLE
Python: properly split tuples containing dictionaries

### DIFF
--- a/ftplugin/python/splitjoin.vim
+++ b/ftplugin/python/splitjoin.vim
@@ -1,9 +1,9 @@
 if !exists('b:splitjoin_split_callbacks')
   let b:splitjoin_split_callbacks = [
+        \ 'sj#python#SplitTuple',
         \ 'sj#python#SplitAssignment',
         \ 'sj#python#SplitDict',
         \ 'sj#python#SplitArray',
-        \ 'sj#python#SplitTuple',
         \ 'sj#python#SplitStatement',
         \ 'sj#python#SplitImport',
         \ ]
@@ -11,9 +11,9 @@ endif
 
 if !exists('b:splitjoin_join_callbacks')
   let b:splitjoin_join_callbacks = [
+        \ 'sj#python#JoinTuple',
         \ 'sj#python#JoinDict',
         \ 'sj#python#JoinArray',
-        \ 'sj#python#JoinTuple',
         \ 'sj#python#JoinStatement',
         \ 'sj#python#JoinImport',
         \ 'sj#python#JoinAssignment',

--- a/spec/plugin/python_spec.rb
+++ b/spec/plugin/python_spec.rb
@@ -184,7 +184,7 @@ describe "python" do
     assert_file_contents <<-EOF
       out = ("one",
               {"two": "three"},
-              "four")
+      "four")
     EOF
 
     vim.search('one')

--- a/spec/plugin/python_spec.rb
+++ b/spec/plugin/python_spec.rb
@@ -172,4 +172,49 @@ describe "python" do
           one, two, three = Some.expression("that returns an array")
     EOF
   end
+
+  specify "dictionary within tuple" do
+    set_file_contents <<-EOF
+      out = ("one", {"two": "three"}, "four")
+    EOF
+
+    vim.search('one')
+    split
+
+    assert_file_contents <<-EOF
+      out = ("one",
+              {"two": "three"},
+              "four")
+    EOF
+
+    vim.search('one')
+    join
+
+    assert_file_contents <<-EOF
+      out = ("one", {"two": "three"}, "four")
+    EOF
+  end
+
+  specify "tuple within dictionary" do
+    set_file_contents <<-EOF
+      out = {"one": "two", "key": ("three", "four")}
+    EOF
+
+    vim.search('one')
+    split
+
+    assert_file_contents <<-EOF
+      out = {
+              "one": "two",
+              "key": ("three", "four")
+              }
+    EOF
+
+    vim.search('out')
+    join
+
+    assert_file_contents <<-EOF
+      out = {"one": "two", "key": ("three", "four")}
+    EOF
+  end
 end


### PR DESCRIPTION
Function arguments are currently parsed as tuples. Without this change, splitting Python function arguments when one argument is a dict will result in the dict begin splitted (instead of the arg list).

Example:

```python
example_func(a, b, {"a": "b"})
```

should be split as, when the cursor is on the opening `(`:
```python
example_func(a,                       
    b,
    {"a": "b"})
```

but without this PR, the result is

```python
example_func(a, b, {
    "a": "b"
})
```
When the cursor is on the opening `{`, the current behaviour is unchanged. The attached tests do not pass on master, but (at least on my box) they pass with this change.

There are some remaining issues with whitespace, but they are also present in master, so I'll investigate them later if I find the time and courage :) 

I am a vimscript newbie, and have not used this plugin for long, so don't hesitate to let me know if I missed something.