### PR TITLE
Vuejs improvements

### DIFF
--- a/autoload/sj/js.vim
+++ b/autoload/sj/js.vim
@@ -122,7 +122,7 @@ function! sj#js#JoinOneLineIf()
   let end_line_no = if_line_no + 2
   let end_line = getline(end_line_no)
 
-  if if_line !~ '^\s*if (.+) {' && end_line !~ '^\s*}\s*$'
+  if if_line !~ '^\s*if (.\+) {' || end_line !~ '^\s*}\s*$'
     return 0
   endif
 

--- a/autoload/sj/js.vim
+++ b/autoload/sj/js.vim
@@ -99,7 +99,7 @@ endfunction
 
 function! sj#js#SplitOneLineIf()
   let line = getline('.')
-  if line =~ '^\s*if (.\+) .\+;'
+  if line =~ '^\s*if (.\+) .\+;\?'
     let lines = []
     " use regular vim movements to know where we have to split
     normal! ^w%

--- a/autoload/sj/vue.vim
+++ b/autoload/sj/vue.vim
@@ -1,33 +1,32 @@
 function! sj#vue#SplitCssDefinition()
-    if s:GetVueSection() != 'style'
-        return 0
-    endif
-    return sj#css#SplitDefinition()
+  if s:GetVueSection() != 'style'
+    return 0
+  endif
+  return sj#css#SplitDefinition()
 endfunction
 
 function! sj#vue#JoinCssDefinition()
-    if s:GetVueSection() != 'style'
-        return 0
-    endif
-    return sj#css#JoinDefinition()
+  if s:GetVueSection() != 'style'
+    return 0
+  endif
+  return sj#css#JoinDefinition()
 endfunction
 
 function! sj#vue#SplitCssMultilineSelector()
-    if s:GetVueSection() != 'style'
-        return 0
-    endif
-    return sj#css#SplitMultilineSelector()
+  if s:GetVueSection() != 'style'
+    return 0
+  endif
+  return sj#css#SplitMultilineSelector()
 endfunction
 
 function! sj#vue#JoinCssMultilineSelector()
-    if s:GetVueSection() != 'style'
-        return 0
-    endif
-    return sj#css#JoinMultilineSelector()
+  if s:GetVueSection() != 'style'
+    return 0
+  endif
+  return sj#css#JoinMultilineSelector()
 endfunction
 
 function! s:GetVueSection()
   let l:startofsection = search('\v^\<(template|script|style)\>', 'bn')
   return substitute(getline(startofsection), '\v[<>]', '', 'g')
 endfunction
-

--- a/autoload/sj/vue.vim
+++ b/autoload/sj/vue.vim
@@ -1,0 +1,33 @@
+function! sj#vue#SplitCssDefinition()
+    if GetVueSection() != 'style'
+        return 0
+    endif
+    return sj#css#SplitDefinition()
+endfunction
+
+function! sj#vue#JoinCssDefinition()
+    if GetVueSection() != 'style'
+        return 0
+    endif
+    return sj#css#JoinDefinition()
+endfunction
+
+function! sj#vue#SplitCssMultilineSelector()
+    if GetVueSection() != 'style'
+        return 0
+    endif
+    return sj#css#SplitMultilineSelector()
+endfunction
+
+function! sj#vue#JoinCssMultilineSelector()
+    if GetVueSection() != 'style'
+        return 0
+    endif
+    return sj#css#JoinMultilineSelector()
+endfunction
+
+function! GetVueSection()
+  let l:startofsection = search('\v^\<(template|script|style)\>', 'bn')
+  return substitute(getline(startofsection), '\v[<>]', '', 'g')
+endfunction
+

--- a/autoload/sj/vue.vim
+++ b/autoload/sj/vue.vim
@@ -1,32 +1,32 @@
 function! sj#vue#SplitCssDefinition()
-    if GetVueSection() != 'style'
+    if s:GetVueSection() != 'style'
         return 0
     endif
     return sj#css#SplitDefinition()
 endfunction
 
 function! sj#vue#JoinCssDefinition()
-    if GetVueSection() != 'style'
+    if s:GetVueSection() != 'style'
         return 0
     endif
     return sj#css#JoinDefinition()
 endfunction
 
 function! sj#vue#SplitCssMultilineSelector()
-    if GetVueSection() != 'style'
+    if s:GetVueSection() != 'style'
         return 0
     endif
     return sj#css#SplitMultilineSelector()
 endfunction
 
 function! sj#vue#JoinCssMultilineSelector()
-    if GetVueSection() != 'style'
+    if s:GetVueSection() != 'style'
         return 0
     endif
     return sj#css#JoinMultilineSelector()
 endfunction
 
-function! GetVueSection()
+function! s:GetVueSection()
   let l:startofsection = search('\v^\<(template|script|style)\>', 'bn')
   return substitute(getline(startofsection), '\v[<>]', '', 'g')
 endfunction

--- a/autoload/sj/vue.vim
+++ b/autoload/sj/vue.vim
@@ -27,6 +27,6 @@ function! sj#vue#JoinCssMultilineSelector()
 endfunction
 
 function! s:GetVueSection()
-  let l:startofsection = search('\v^\<(template|script|style)\>', 'bn')
+  let l:startofsection = search('\v^\<(template|script|style)\>', 'bnW')
   return substitute(getline(startofsection), '\v[<>]', '', 'g')
 endfunction

--- a/ftplugin/vue/splitjoin.vim
+++ b/ftplugin/vue/splitjoin.vim
@@ -1,21 +1,21 @@
 let b:splitjoin_split_callbacks = [
       \ 'sj#html#SplitTags',
       \ 'sj#html#SplitAttributes',
-      \ 'sj#css#SplitDefinition',
-      \ 'sj#css#SplitMultilineSelector',
+      \ 'sj#vue#SplitCssDefinition',
+      \ 'sj#vue#SplitCssMultilineSelector',
       \ 'sj#js#SplitFatArrowFunction',
       \ 'sj#js#SplitArray',
       \ 'sj#js#SplitObjectLiteral',
       \ 'sj#js#SplitFunction',
       \ 'sj#js#SplitOneLineIf',
-      \ 'sj#js#SplitArgs'
-      \ ]
+      \ 'sj#js#SplitArgs',
+\ ]
 
 let b:splitjoin_join_callbacks = [
       \ 'sj#html#JoinAttributes',
       \ 'sj#html#JoinTags',
-      \ 'sj#css#JoinDefinition',
-      \ 'sj#css#JoinMultilineSelector',
+      \ 'sj#vue#JoinCssDefinition',
+      \ 'sj#vue#JoinCssMultilineSelector',
       \ 'sj#js#JoinFatArrowFunction',
       \ 'sj#js#JoinArray',
       \ 'sj#js#JoinArgs',


### PR DESCRIPTION
I was having problems with .vue files, has it has several syntax in one. 
When trying to split / join an object literal between script tags, it would detect it as a css definition (as the plugin uses the first split/join function that matches.

I have extracted the css function definitions for vue file so that they are only executed between style tags. 

I also had a few problems with split/join for one life ifs in javascript, fixed it too.