### PR TITLE
Vim: support joining/splitting :if commands

### DIFF
--- a/autoload/sj/vim.vim
+++ b/autoload/sj/vim.vim
@@ -36,6 +36,24 @@ function! sj#vim#Join()
   endif
 endfunction
 
+function! sj#vim#SplitIfClause()
+  let line = getline('.')
+  let pattern = '\v^\s*if .{-} \| .{-} \|\s*endif'
+
+  if line !~# pattern
+    return 0
+  endif
+
+  let line_no = line('.')
+  let lines = split(line, '|')
+  let lines = map(lines, 'sj#Trim(v:val)')
+  let replacement = join(lines, "\n")
+
+  call sj#ReplaceLines(line_no, line_no, replacement)
+
+  return 1
+endfunction
+
 function! sj#vim#JoinIfClause()
   let line = getline('.')
   let pattern = '\v^\s*if'

--- a/autoload/sj/vim.vim
+++ b/autoload/sj/vim.vim
@@ -35,3 +35,33 @@ function! sj#vim#Join()
     return 1
   endif
 endfunction
+
+function! sj#vim#JoinIfClause()
+  let line = getline('.')
+  let pattern = '\v^\s*if'
+
+  if line !~# pattern
+    return 0
+  endif
+
+  let if_line_no = line('.')
+  let endif_line_pattern = '^'.repeat(' ', indent(if_line_no)).'endif'
+
+  let endif_line_no = search(endif_line_pattern, 'W')
+
+  if endif_line_no <= 0
+    return 0
+  endif
+
+  if endif_line_no - if_line_no != 2
+    return 0
+  endif
+
+  let lines = sj#GetLines(if_line_no, endif_line_no)
+  let lines = map(lines, 'sj#Trim(v:val)')
+  let replacement = join(lines, ' | ')
+
+  call sj#ReplaceLines(if_line_no, endif_line_no, replacement)
+
+  return 1
+endfunction

--- a/ftplugin/vim/splitjoin.vim
+++ b/ftplugin/vim/splitjoin.vim
@@ -1,5 +1,6 @@
 if !exists('b:splitjoin_split_callbacks')
   let b:splitjoin_split_callbacks = [
+        \ 'sj#vim#SplitIfClause',
         \ 'sj#vim#Split',
         \ ]
 endif

--- a/ftplugin/vim/splitjoin.vim
+++ b/ftplugin/vim/splitjoin.vim
@@ -6,6 +6,7 @@ endif
 
 if !exists('b:splitjoin_join_callbacks')
   let b:splitjoin_join_callbacks = [
+        \ 'sj#vim#JoinIfClause',
         \ 'sj#vim#Join',
         \ ]
 endif

--- a/spec/plugin/vim_spec.rb
+++ b/spec/plugin/vim_spec.rb
@@ -1,0 +1,26 @@
+require 'spec_helper'
+
+describe "vim" do
+  let(:filename) { "test.vim" }
+
+  before :each do
+    vim.set 'expandtab'
+    vim.set 'shiftwidth', 2
+  end
+
+  specify ":if commands" do
+    contents = <<-EOF
+      if condition == 1
+        return 0
+      endif
+    EOF
+
+    set_file_contents contents
+
+    join
+    assert_file_contents "if condition == 1 | return 0 | endif"
+
+    split
+    assert_file_contents contents
+  end
+end


### PR DESCRIPTION
Hi,

This PR adds support for joining/splitting `:if` commands in Vim scripts.

From..

```vim
if condition
  single line body
endif
```

..to..

```vim
if condition | single line body | endif
```

..and vice versa.

That might be uncommon in Vim, opposed to languages like JavaScript, but since this plugin doesn't treat `:if` specially so far, I thought I'd just go for it.

What do you think?