### PR TITLE
Fix splitting nested yaml objects inside an array

### DIFF
--- a/spec/plugin/yaml_spec.rb
+++ b/spec/plugin/yaml_spec.rb
@@ -59,6 +59,22 @@ describe "yaml" do
         root: ['one', 'two']
       EOF
     end
+
+    specify "nested objects inside an array" do
+      set_file_contents <<-EOF
+        root:
+          - one: { foo: bar }
+      EOF
+
+      vim.search 'one'
+      split
+
+      assert_file_contents <<-EOF
+        root:
+          - one:
+              foo: bar
+      EOF
+    end
   end
 
   describe "maps" do


### PR DESCRIPTION
When splitting an object inside an array in yaml, the indention was not correct.

**Example:**

```yaml
root:
  - one: { foo: bar }
```
should be splitted to
```yaml
root:
  - one:
      foo: bar
```
**NOT**
```yaml
root:
  - one:
    foo: bar
```