### PR TITLE
Add tsx filetype support (identical to jsx config)

### DIFF
--- a/ftplugin/tsx/splitjoin.vim
+++ b/ftplugin/tsx/splitjoin.vim
@@ -1,0 +1,21 @@
+let b:splitjoin_split_callbacks = [
+      \ 'sj#html#SplitTags',
+      \ 'sj#html#SplitAttributes',
+      \ 'sj#js#SplitObjectLiteral',
+      \ 'sj#js#SplitFatArrowFunction',
+      \ 'sj#js#SplitArray',
+      \ 'sj#js#SplitFunction',
+      \ 'sj#js#SplitOneLineIf',
+      \ 'sj#js#SplitArgs'
+      \ ]
+
+let b:splitjoin_join_callbacks = [
+      \ 'sj#html#JoinAttributes',
+      \ 'sj#html#JoinTags',
+      \ 'sj#js#JoinFatArrowFunction',
+      \ 'sj#js#JoinArray',
+      \ 'sj#js#JoinArgs',
+      \ 'sj#js#JoinFunction',
+      \ 'sj#js#JoinOneLineIf',
+      \ 'sj#js#JoinObjectLiteral',
+      \ ]


### PR DESCRIPTION
Just like with JSX files, TypeScript's TSX equivalent filetype needs the ability to operate on tags and attributes. Not sure if there's a good way to more intelligently link them, but this brings the tsx files up to feature parity.