### PR TITLE
yaml improvements

### DIFF
--- a/autoload/sj/yaml.vim
+++ b/autoload/sj/yaml.vim
@@ -4,7 +4,9 @@ function! sj#yaml#SplitArray()
   let whitespace = s:GetIndentWhitespace(line_no)
 
   if line =~ ':\s*\[.*\]\s*\(#.*\)\?$'
-    let [key_part, array_part] = split(line, ':')
+    let parts      = split(line, ':')
+    let key_part   = parts[0]
+    let array_part = join(parts[1:], ':')
     let array_part             = sj#ExtractRx(array_part, '\[\(.*\)\]', '\1')
     let expanded_array         = split(array_part, ',\s*')
     let body                   = join(expanded_array, "\n- ")

--- a/autoload/sj/yaml.vim
+++ b/autoload/sj/yaml.vim
@@ -110,7 +110,7 @@ function! sj#yaml#SplitMap()
     " E.g.
     "   prop: { one: 1 }
     "   - prop: { one: 1 }
-    if line =~ '^\v\s*(-\s+)*.*:\s\{.*'
+    if line =~ '^\v\s*(-\s+)*[^{]*:\s\{.*'
       let body          = "\n" . body
       let indent_level += 1
       let end_offset    = 0
@@ -472,7 +472,7 @@ endfunction
 "   - foo    => 1
 "   - - bar  => 2
 function! s:NestedArrayLevel(line)
-  let prefix = substitute(a:line, '^\s*((-\s+)+).*', '\1', '')
+  let prefix = substitute(a:line, '\v^\s*((-\s+)+).*', '\1', '')
   let levels = substitute(prefix, '[^-]', '', 'g')
   return len(levels)
 endfunction

--- a/autoload/sj/yaml.vim
+++ b/autoload/sj/yaml.vim
@@ -99,6 +99,7 @@ function! sj#yaml#SplitMap()
     let line  = s:StripComment(line)
     let pairs = sj#ParseJsonObjectBody(from + 1, to - 1)
     let body  = join(pairs, "\n")
+    let body_start = line_no
 
     let indent_level = 0
     let end_offset   = -1
@@ -118,6 +119,7 @@ function! sj#yaml#SplitMap()
       let body          = "\n" . body
       let indent_level += 1
       let end_offset    = 0
+      let body_start    = line_no + 1
     endif
 
     call sj#ReplaceMotion('Va{', body)
@@ -127,8 +129,7 @@ function! sj#yaml#SplitMap()
     call sj#Keeppatterns(line_no . 's/\s*$//e')
 
     if sj#settings#Read('align')
-      let body_start = line_no + 1
-      let body_end   = body_start + len(pairs) - 1
+      let body_end = body_start + len(pairs) - 1
       call sj#Align(body_start, body_end, 'json_object')
     endif
 

--- a/autoload/sj/yaml.vim
+++ b/autoload/sj/yaml.vim
@@ -247,6 +247,19 @@ function! s:GetChildren(line_no)
   let indent       = indent(line_no)
   let next_line    = getline(next_line_no)
 
+  " Count '- ' as indent, if an object is in an array
+  " E.g. (GetChildren for prop_a)
+  "   list:
+  "     - prop_a:
+  "         - 1
+  "       prop_b
+  "         - 2
+  let line = getline(line_no)
+  if line =~ '^\s*\(\-\s\s*\)..*:$'
+    let prefix = substitute(getline(a:line_no), '^\s*\(\-\s\s*\)..*:$', '\1', '')
+    let indent += len(prefix)
+  end
+
   while s:IsValidLineNo(next_line_no) &&
         \ (sj#BlankString(next_line) || indent(next_line_no) > indent)
     let next_line_no = next_line_no + 1

--- a/autoload/sj/yaml.vim
+++ b/autoload/sj/yaml.vim
@@ -10,18 +10,19 @@ function! sj#yaml#SplitArray()
   let end_offset = 0
 
   let nestedExp = '\v^\s*((-\s+)+)(\[.*\])$'
+  let line = s:StripComment(line)
 
   " Split arrays which are map properties
   " E.g.
   "   prop: [1, 2]
-  if s:StripComment(line) =~ ':\s*\[.*\]$'
+  if line =~ ':\s*\[.*\]$'
     let [key, array_part] = s:SplitKeyValue(line)
     let prefix            = key . ":\n"
 
   " Split nested arrays
   " E.g.
   "   - [1, 2]
-  elseif s:StripComment(line) =~ nestedExp
+  elseif line =~ nestedExp
     let prefix     = substitute(line, nestedExp, '\1', '')
     let array_part = substitute(line, nestedExp, '\3', '')
     let indent     = len(substitute(line, '\v[^-]', '', 'g'))
@@ -55,7 +56,7 @@ function! sj#yaml#JoinArray()
   " E.g.
   "   - - 'one'
   "     - 'two'
-  if s:StripComment(line) =~ nestedExp && s:IsValidLineNo(line_no)
+  if first_line =~ nestedExp && s:IsValidLineNo(line_no)
     let [lines, last_line_no] = s:GetChildren(line_no)
     let lines = map(lines, 's:StripComment(v:val)')
     let lines = [substitute(first_line, nestedExp, '\3', '')] + lines
@@ -66,7 +67,7 @@ function! sj#yaml#JoinArray()
   "  list:
   "    - 'one'
   "    - 'two'
-  elseif s:StripComment(line) =~ ':$' && s:IsValidLineNo(line_no + 1)
+  elseif first_line =~ ':$' && s:IsValidLineNo(line_no + 1)
     let [lines, last_line_no] = s:GetChildren(line_no)
     let lines = map(lines, 's:StripComment(v:val)')
   endif

--- a/autoload/sj/yaml.vim
+++ b/autoload/sj/yaml.vim
@@ -78,7 +78,7 @@ endfunction
 function! sj#yaml#SplitMap()
   let [from, to] = sj#LocateBracesOnLine('{', '}')
 
-  if !s:isValidLineNo(from) || !s:isValidLineNo(to)
+  if from >= 0 && to >= 0
     let [line, line_no, whitespace] = s:readCurrentLine()
     let pairs      = sj#ParseJsonObjectBody(from + 1, to - 1)
     let body       = "\n".join(pairs, "\n")

--- a/autoload/sj/yaml.vim
+++ b/autoload/sj/yaml.vim
@@ -120,7 +120,7 @@ function! sj#yaml#SplitMap()
     silent! normal! zO
     call s:SetIndentWhitespace(line_no, whitespace)
     call s:IncreaseIndentWhitespace(line_no + 1, line_no + len(pairs) + end_offset, whitespace, indent_level)
-    exe line_no . 's/\s*$//e'
+    call sj#Keeppatterns(line_no . 's/\s*$//e')
 
     if sj#settings#Read('align')
       let body_start = line_no + 1
@@ -225,7 +225,7 @@ function! s:GetIndentWhitespace(line_no)
 endfunction
 
 function! s:SetIndentWhitespace(line_no, whitespace)
-  silent exe a:line_no . 's/^\s*/' . a:whitespace
+  silent call sj#Keeppatterns(a:line_no . 's/^\s*/' . a:whitespace)
 endfunction
 
 function! s:IncreaseIndentWhitespace(from, to, whitespace, level)

--- a/autoload/sj/yaml.vim
+++ b/autoload/sj/yaml.vim
@@ -203,7 +203,7 @@ function! s:ReadCurrentLine()
 endfunction
 
 function! s:StripComment(s)
-  return substitute(a:s, '\s*#.*$', '', '')
+  return substitute(a:s, '\v\s+#.*$', '', '')
 endfunction
 
 function! s:IsValidLineNo(no)

--- a/autoload/sj/yaml.vim
+++ b/autoload/sj/yaml.vim
@@ -4,9 +4,7 @@ function! sj#yaml#SplitArray()
   let whitespace = s:GetIndentWhitespace(line_no)
 
   if line =~ ':\s*\[.*\]\s*\(#.*\)\?$'
-    let parts      = split(line, ':')
-    let key_part   = parts[0]
-    let array_part = join(parts[1:], ':')
+    let [key_part, array_part] = s:splitKeyValue(line)
     let array_part             = sj#ExtractRx(array_part, '\[\(.*\)\]', '\1')
     let expanded_array         = s:splitArrayLines(array_part)
     let body                   = join(expanded_array, "\n- ")
@@ -215,5 +213,13 @@ function! s:convertToSingleLine(line)
   endif
 
   return line
+endfunction
+
+function! s:splitKeyValue(line)
+  let parts = split(a:line, ':')
+  if len(parts) >= 2
+    return [sj#Trim(parts[0]), sj#Trim(join(parts[1:], ':'))]
+  endif
+  return ['', a:line]
 endfunction
 

--- a/autoload/sj/yaml.vim
+++ b/autoload/sj/yaml.vim
@@ -141,6 +141,11 @@ function! s:GetChildren(line_no)
   endwhile
   let next_line_no = next_line_no - 1
 
+  " Preserve trailing empty lines
+  while sj#BlankString(getline(next_line_no)) && next_line_no > line_no
+    let next_line_no = next_line_no - 1
+  endwhile
+
   return [sj#GetLines(line_no + 1, next_line_no), next_line_no]
 endfunction
 

--- a/autoload/sj/yaml.vim
+++ b/autoload/sj/yaml.vim
@@ -57,6 +57,7 @@ function! sj#yaml#JoinArray()
   "     - 'two'
   if s:StripComment(line) =~ nestedExp && s:IsValidLineNo(line_no)
     let [lines, last_line_no] = s:GetChildren(line_no)
+    let lines = map(lines, 's:StripComment(v:val)')
     let lines = [substitute(first_line, nestedExp, '\3', '')] + lines
     let first_line = sj#Rtrim(substitute(first_line, nestedExp, '\1', ''))
 
@@ -67,6 +68,7 @@ function! sj#yaml#JoinArray()
   "    - 'two'
   elseif s:StripComment(line) =~ ':$' && s:IsValidLineNo(line_no + 1)
     let [lines, last_line_no] = s:GetChildren(line_no)
+    let lines = map(lines, 's:StripComment(v:val)')
   endif
 
   if !empty(lines) && lines[0] =~ '^\s*-'
@@ -93,6 +95,7 @@ function! sj#yaml#SplitMap()
 
   if from >= 0 && to >= 0
     let [line, line_no, whitespace] = s:ReadCurrentLine()
+    let line  = s:StripComment(line)
     let pairs = sj#ParseJsonObjectBody(from + 1, to - 1)
     let body  = join(pairs, "\n")
 
@@ -177,6 +180,7 @@ function! sj#yaml#JoinMap()
   if len(lines) > 0
     let lines = sj#TrimList(lines)
     let lines = s:NormalizeWhitespace(lines)
+    let lines = map(lines, 's:StripComment(v:val)')
 
     let replacement = first_line . ' { '. join(lines, ', ') . ' }'
 

--- a/autoload/sj/yaml.vim
+++ b/autoload/sj/yaml.vim
@@ -202,14 +202,17 @@ function! s:ReadCurrentLine()
   return [line, line_no, whitespace]
 endfunction
 
+" Strip comments from string starting with a #
 function! s:StripComment(s)
   return substitute(a:s, '\v\s+#.*$', '', '')
 endfunction
 
+" Check if current buffer has the line number
 function! s:IsValidLineNo(no)
   return a:no >= 0  && a:no <= line('$')
 endfunction
 
+" Normalize whitespace, if enabled
 function! s:NormalizeWhitespace(lines)
   if sj#settings#Read('normalize_whitespace')
     return map(a:lines, 'substitute(v:val, ":\\s\\+", ": ", "")')
@@ -334,17 +337,17 @@ endfunction
 " E.q.
 "  '[[1, 2]], [1]' => ['[[1, 2]], ', [1]']
 function! s:ReadArray(str)
-  return s:ReadStructure(a:str, '[', ']')
+  return s:ReadContainer(a:str, '[', ']')
 endfunction
 
 " Read the next map, including nested maps.
 " E.q.
 "  '{ one: 1, foo: { two: 2 } }, {}' => ['{ one: 1, foo: { two: 2 } }, ', {}']
 function! s:ReadMap(str)
-  return s:ReadStructure(a:str, '{', '}')
+  return s:ReadContainer(a:str, '{', '}')
 endfunction
 
-function! s:ReadStructure(str, start_char, end_char)
+function! s:ReadContainer(str, start_char, end_char)
   let content = ''
   let rest = a:str
   let depth = 0

--- a/autoload/sj/yaml.vim
+++ b/autoload/sj/yaml.vim
@@ -170,6 +170,11 @@ function! sj#yaml#JoinMap()
     let lines = [substitute(first_line, nestedExp, '\3', '')] + lines
     let first_line = sj#Rtrim(substitute(first_line, nestedExp, '\1', ''))
 
+    if len(lines) <= 1
+      " only 1 line means nothing to join in this case
+      return 0
+    endif
+
   " Normal map
   " E.g.
   "   map:

--- a/autoload/sj/yaml.vim
+++ b/autoload/sj/yaml.vim
@@ -139,7 +139,7 @@ function! sj#yaml#JoinMap()
   " E.g.
   "  - prop:
   "     one: 1
-  if line =~ nestedPropExp
+  if first_line =~ nestedPropExp
     let [lines, last_line_no] = s:GetChildren(line_no)
     let first_line = sj#Rtrim(substitute(first_line, nestedPropExp, '\1', ''))
 
@@ -147,13 +147,13 @@ function! sj#yaml#JoinMap()
   " E.g.
   "  - one: 1
   "    two: 2
-  elseif line =~ nestedExp
+  elseif first_line =~ nestedExp
     let [lines, last_line_no] = s:GetChildren(line_no)
     let lines = [substitute(first_line, nestedExp, '\3', '')] + lines
     let first_line = sj#Rtrim(substitute(first_line, nestedExp, '\1', ''))
 
   " Normal map
-  elseif line =~ '\k\+:\s*$'
+  elseif first_line =~ '\k\+:\s*$'
     let [lines, last_line_no] = s:GetChildren(line_no)
   endif
 

--- a/autoload/sj/yaml.vim
+++ b/autoload/sj/yaml.vim
@@ -110,7 +110,7 @@ function! sj#yaml#SplitMap()
     " E.g.
     "   prop: { one: 1 }
     "   - prop: { one: 1 }
-    if line =~ '^\v\s*(-\s+)*[^{]*:\s\{.*'
+    if line =~ '^\v\s*(-\s+)*[^{]*:\s+\{.*'
       let body          = "\n" . body
       let indent_level += 1
       let end_offset    = 0

--- a/spec/plugin/yaml_spec.rb
+++ b/spec/plugin/yaml_spec.rb
@@ -85,6 +85,31 @@ describe "yaml" do
       EOF
     end
 
+    specify "with strings containing a comma" do
+      set_file_contents <<~EOF
+        root:
+          - 'one, foo'
+          - 'two, bar'
+
+      EOF
+
+      vim.search 'root'
+      join
+
+      assert_file_contents <<~EOF
+        root: ['one, foo', 'two, bar']
+      EOF
+
+      vim.search 'root'
+      split
+
+      assert_file_contents <<~EOF
+        root:
+          - 'one, foo'
+          - 'two, bar'
+      EOF
+    end
+
     specify "nested objects inside an array" do
       set_file_contents <<~EOF
         root:

--- a/spec/plugin/yaml_spec.rb
+++ b/spec/plugin/yaml_spec.rb
@@ -60,6 +60,31 @@ describe "yaml" do
       EOF
     end
 
+    specify "with strings containing a colon" do
+      set_file_contents <<~EOF
+        root:
+          - 'one: foo'
+          - 'two: bar'
+
+      EOF
+
+      vim.search 'root'
+      join
+
+      assert_file_contents <<~EOF
+        root: ['one: foo', 'two: bar']
+      EOF
+
+      vim.search 'root'
+      split
+
+      assert_file_contents <<~EOF
+        root:
+          - 'one: foo'
+          - 'two: bar'
+      EOF
+    end
+
     specify "nested objects inside an array" do
       set_file_contents <<~EOF
         root:

--- a/spec/plugin/yaml_spec.rb
+++ b/spec/plugin/yaml_spec.rb
@@ -201,7 +201,7 @@ describe "yaml" do
       EOF
     end
 
-    specify "containing mulitline maps" do
+    specify "containing mulitline maps (recursive)" do
       pending 'Not implemented'
 
       set_file_contents <<~EOF
@@ -218,7 +218,7 @@ describe "yaml" do
       EOF
     end
 
-    specify "containing arrays" do
+    specify "containing arrays (recursive)" do
       pending 'Not implemented'
 
       set_file_contents <<~EOF
@@ -287,6 +287,8 @@ describe "yaml" do
         list:
           - - - 1
               - 2
+          - - - 3
+        end: true
       EOF
 
       vim.search '1'
@@ -295,6 +297,8 @@ describe "yaml" do
       assert_file_contents <<~EOF
         list:
           - - [1, 2]
+          - - - 3
+        end: true
       EOF
 
       vim.search '1'
@@ -303,16 +307,38 @@ describe "yaml" do
       assert_file_contents <<~EOF
         list:
           - [[1, 2]]
+          - - - 3
+        end: true
+      EOF
+
+      vim.search '3'
+      join
+
+      assert_file_contents <<~EOF
+        list:
+          - [[1, 2]]
+          - - [3]
+        end: true
+      EOF
+
+      vim.search '3'
+      join
+
+      assert_file_contents <<~EOF
+        list:
+          - [[1, 2]]
+          - [[3]]
+        end: true
       EOF
 
       vim.search 'list'
       join
 
       assert_file_contents <<~EOF
-        list: [[[1, 2]]]
+        list: [[[1, 2]], [[3]]]
+        end: true
       EOF
     end
-
   end
 
   describe "maps" do

--- a/spec/plugin/yaml_spec.rb
+++ b/spec/plugin/yaml_spec.rb
@@ -511,6 +511,25 @@ describe "yaml" do
       EOF
     end
 
+    specify "splitting inside an array, with complex properties" do
+      set_file_contents <<~EOF
+        list:
+          - { one: 1, two: [ 'foo', 'bar' ], three: { foo: 'item-1', bar: 'item-2' } }
+        end: true
+      EOF
+
+      vim.search 'one:'
+      split
+
+      assert_file_contents <<~EOF
+        list:
+          - one: 1
+            two: [ 'foo', 'bar' ]
+            three: { foo: 'item-1', bar: 'item-2' }
+        end: true
+      EOF
+    end
+
     specify "joining inside an array and map" do
       set_file_contents <<~EOF
         list:

--- a/spec/plugin/yaml_spec.rb
+++ b/spec/plugin/yaml_spec.rb
@@ -125,6 +125,51 @@ describe "yaml" do
       EOF
     end
 
+    specify "list of simple objects" do
+      set_file_contents <<~EOF
+        list: [{ prop: 1 }, { prop: 2 }]
+      EOF
+
+      vim.search 'list'
+      split
+
+      assert_file_contents <<~EOF
+        list:
+          - prop: 1
+          - prop: 2
+      EOF
+
+      vim.search 'list'
+      join
+
+      assert_file_contents <<~EOF
+        list: [{ prop: 1 }, { prop: 2 }]
+      EOF
+    end
+
+    specify "containing mixed elements" do
+      set_file_contents <<~EOF
+        list: [{ prop: 1 }, { a: 1, b: 2 }, "a: b"]
+      EOF
+
+      vim.search 'list'
+      split
+
+      assert_file_contents <<~EOF
+        list:
+          - prop: 1
+          - { a: 1, b: 2 }
+          - "a: b"
+      EOF
+
+      vim.search 'list'
+      join
+
+      assert_file_contents <<~EOF
+        list: [{ prop: 1 }, { a: 1, b: 2 }, "a: b"]
+      EOF
+    end
+
     specify "preserve empty lines" do
       set_file_contents <<~EOF
         list:

--- a/spec/plugin/yaml_spec.rb
+++ b/spec/plugin/yaml_spec.rb
@@ -393,8 +393,6 @@ describe "yaml" do
     end
 
     specify "joining inside an array" do
-      pending 'Not implemented'
-
       set_file_contents <<~EOF
         list:
           - one: 1
@@ -426,6 +424,25 @@ describe "yaml" do
         list:
           - one: 1
             two: 2
+        end: true
+      EOF
+    end
+
+    specify "joining inside an array and map" do
+      set_file_contents <<~EOF
+        list:
+          - foo:
+              one: 1
+              two: 2
+        end: true
+      EOF
+
+      vim.search 'foo:'
+      join
+
+      assert_file_contents <<~EOF
+        list:
+          - foo: { one: 1, two: 2 }
         end: true
       EOF
     end

--- a/spec/plugin/yaml_spec.rb
+++ b/spec/plugin/yaml_spec.rb
@@ -370,6 +370,32 @@ describe "yaml" do
         root#list: ['one', 'two']
       EOF
     end
+
+    specify "joining inside an array and map with other properties" do
+      set_file_contents <<~EOF
+        list:
+          - foo:
+              - 1
+              - 2
+            bar:
+              one: 1
+              two: 2
+        end: true
+      EOF
+
+      vim.search 'foo:'
+      join
+
+      assert_file_contents <<~EOF
+        list:
+          - foo: [1, 2]
+            bar:
+              one: 1
+              two: 2
+        end: true
+      EOF
+    end
+
   end
 
   describe "maps" do
@@ -500,6 +526,31 @@ describe "yaml" do
       assert_file_contents <<~EOF
         list:
           - foo: { one: 1, two: 2 }
+        end: true
+      EOF
+    end
+
+    specify "joining inside an array and map with other properties" do
+      set_file_contents <<~EOF
+        list:
+          - foo:
+              one: 1
+              two: 2
+            bar:
+              one: 1
+              two: 2
+        end: true
+      EOF
+
+      vim.search 'foo:'
+      join
+
+      assert_file_contents <<~EOF
+        list:
+          - foo: { one: 1, two: 2 }
+            bar:
+              one: 1
+              two: 2
         end: true
       EOF
     end

--- a/spec/plugin/yaml_spec.rb
+++ b/spec/plugin/yaml_spec.rb
@@ -392,13 +392,14 @@ describe "yaml" do
       EOF
     end
 
-    specify "inside an array" do
+    specify "joining inside an array" do
       pending 'Not implemented'
 
       set_file_contents <<~EOF
         list:
           - one: 1
             two: 2
+        end: true
       EOF
 
       vim.search 'one:'
@@ -407,7 +408,46 @@ describe "yaml" do
       assert_file_contents <<~EOF
         list:
           - { one: 1, two: 2 }
+        end: true
       EOF
     end
+
+    specify "splitting inside an array" do
+      set_file_contents <<~EOF
+        list:
+          - { one: 1, two: 2 }
+        end: true
+      EOF
+
+      vim.search 'one:'
+      split
+
+      assert_file_contents <<~EOF
+        list:
+          - one: 1
+            two: 2
+        end: true
+      EOF
+    end
+
+    specify "splitting inside an array and map" do
+      set_file_contents <<~EOF
+        list:
+          - foo: { one: 1, two: 2 }
+        end: true
+      EOF
+
+      vim.search 'foo:'
+      split
+
+      assert_file_contents <<~EOF
+        list:
+          - foo:
+              one: 1
+              two: 2
+        end: true
+      EOF
+    end
+
   end
 end

--- a/spec/plugin/yaml_spec.rb
+++ b/spec/plugin/yaml_spec.rb
@@ -354,6 +354,21 @@ describe "yaml" do
         end: true
       EOF
     end
+
+    specify "stripping comments" do
+      set_file_contents <<~EOF
+        root:     # root object
+          - 'one'
+          - 'two'
+      EOF
+
+      vim.search 'root'
+      join
+
+      assert_file_contents <<~EOF
+        root: ['one', 'two']
+      EOF
+    end
   end
 
   describe "maps" do
@@ -523,5 +538,30 @@ describe "yaml" do
         map: { foo: { bar: 1 } }
       EOF
     end
+
+    specify "stripping comments" do
+      set_file_contents <<~EOF
+        root_a:     # root object
+          a: 'one'
+          b: 'two'
+        root_b:
+          - prop:   # nested object
+              a: 'one'
+              b: 'two'
+      EOF
+
+      vim.search 'root_a'
+      join
+
+      vim.search 'prop'
+      join
+
+      assert_file_contents <<~EOF
+        root_a: { a: 'one', b: 'two' }
+        root_b:
+          - prop: { a: 'one', b: 'two' }
+      EOF
+    end
+
   end
 end

--- a/spec/plugin/yaml_spec.rb
+++ b/spec/plugin/yaml_spec.rb
@@ -253,6 +253,71 @@ describe "yaml" do
       EOF
     end
 
+    specify "split nested arrays" do
+      set_file_contents <<~EOF
+        list: [[[1, 2]]]
+      EOF
+
+      vim.search 'list'
+      split
+
+      assert_file_contents <<~EOF
+        list:
+          - [[1, 2]]
+      EOF
+
+      vim.search '1'
+      split
+
+      assert_file_contents <<~EOF
+        list:
+          - - [1, 2]
+      EOF
+
+      vim.search '1'
+      split
+
+      assert_file_contents <<~EOF
+        list:
+          - - - 1
+              - 2
+      EOF
+    end
+
+
+    specify "join nested arrays" do
+      pending 'Not implemented'
+
+      set_file_contents <<~EOF
+        list:
+          - - - 1
+              - 2
+      EOF
+
+      vim.search '1'
+      join
+
+      assert_file_contents <<~EOF
+        list:
+          - - [1, 2]
+      EOF
+
+      vim.search '1'
+      join
+
+      assert_file_contents <<~EOF
+        list:
+          - [[1, 2]]
+      EOF
+
+      vim.search 'list'
+      join
+
+      assert_file_contents <<~EOF
+        list: [[[1, 2]]]
+      EOF
+    end
+
   end
 
   describe "maps" do

--- a/spec/plugin/yaml_spec.rb
+++ b/spec/plugin/yaml_spec.rb
@@ -142,7 +142,7 @@ describe "yaml" do
 
     specify "list of simple objects" do
       set_file_contents <<~EOF
-        list: [{ aprop: 1 }, { aProp: 2 }, { 'a:prop': 3 }, { a prop: 4 }]
+        list: [{ aprop: 1 }, { aProp: 2 }, { 'a:prop': 3 }, { a prop: 4 }, { a#prop: 5 }]
       EOF
 
       vim.search 'list'
@@ -154,13 +154,14 @@ describe "yaml" do
           - aProp: 2
           - 'a:prop': 3
           - a prop: 4
+          - a#prop: 5
       EOF
 
       vim.search 'list'
       join
 
       assert_file_contents <<~EOF
-        list: [{ aprop: 1 }, { aProp: 2 }, { 'a:prop': 3 }, { a prop: 4 }]
+        list: [{ aprop: 1 }, { aProp: 2 }, { 'a:prop': 3 }, { a prop: 4 }, { a#prop: 5 }]
       EOF
     end
 
@@ -357,7 +358,7 @@ describe "yaml" do
 
     specify "stripping comments" do
       set_file_contents <<~EOF
-        root:     # root object
+        root#list:     # root object
           - 'one'
           - 'two'
       EOF
@@ -366,7 +367,7 @@ describe "yaml" do
       join
 
       assert_file_contents <<~EOF
-        root: ['one', 'two']
+        root#list: ['one', 'two']
       EOF
     end
   end
@@ -541,11 +542,11 @@ describe "yaml" do
 
     specify "stripping comments" do
       set_file_contents <<~EOF
-        root_a:     # root object
+        root_a#list: # root object
           a: 'one'
           b: 'two'
-        root_b:
-          - prop:   # nested object
+        root_b#list:
+          - prop:    # nested object
               a: 'one'
               b: 'two'
       EOF
@@ -557,8 +558,8 @@ describe "yaml" do
       join
 
       assert_file_contents <<~EOF
-        root_a: { a: 'one', b: 'two' }
-        root_b:
+        root_a#list: { a: 'one', b: 'two' }
+        root_b#list:
           - prop: { a: 'one', b: 'two' }
       EOF
     end

--- a/spec/plugin/yaml_spec.rb
+++ b/spec/plugin/yaml_spec.rb
@@ -65,7 +65,6 @@ describe "yaml" do
         root:
           - 'one: foo'
           - 'two: bar'
-
       EOF
 
       vim.search 'root'
@@ -125,6 +124,34 @@ describe "yaml" do
               foo: bar
       EOF
     end
+
+    specify "preserve empty lines" do
+      set_file_contents <<~EOF
+        list:
+          - 1
+
+        end: true
+      EOF
+
+      vim.search 'list'
+      join
+
+      assert_file_contents <<~EOF
+        list: [1]
+
+        end: true
+      EOF
+
+      vim.search 'list'
+      split
+
+      assert_file_contents <<~EOF
+        list:
+          - 1
+
+        end: true
+      EOF
+    end
   end
 
   describe "maps" do
@@ -158,6 +185,34 @@ describe "yaml" do
         root:
           one: { foo: bar }
           two: { three: ['four', 'five'], six: seven }
+      EOF
+    end
+
+    specify "preserve empty lines" do
+      set_file_contents <<~EOF
+        map:
+          one: 1
+
+        end: true
+      EOF
+
+      vim.search ''
+      join
+
+      assert_file_contents <<~EOF
+        map: { one: 1 }
+
+        end: true
+      EOF
+
+      vim.search 'map'
+      split
+
+      assert_file_contents <<~EOF
+        map:
+          one: 1
+
+        end: true
       EOF
     end
   end

--- a/spec/plugin/yaml_spec.rb
+++ b/spec/plugin/yaml_spec.rb
@@ -360,7 +360,7 @@ describe "yaml" do
       set_file_contents <<~EOF
         root#list:     # root object
           - 'one'
-          - 'two'
+          - 'two' # second record
       EOF
 
       vim.search 'root'
@@ -628,10 +628,10 @@ describe "yaml" do
       set_file_contents <<~EOF
         root_a#list: # root object
           a: 'one'
-          b: 'two'
+          b: 'two' # one more
         root_b#list:
           - prop:    # nested object
-              a: 'one'
+              a: 'one' # another
               b: 'two'
       EOF
 

--- a/spec/plugin/yaml_spec.rb
+++ b/spec/plugin/yaml_spec.rb
@@ -197,6 +197,59 @@ describe "yaml" do
         end: true
       EOF
     end
+
+    specify "containing mulitline maps" do
+      pending 'Not implemented'
+
+      set_file_contents <<~EOF
+        list:
+          - one: 1
+            two: 2
+      EOF
+
+      vim.search 'list'
+      join
+
+      assert_file_contents <<~EOF
+        list: [{ one: 1, two: 2 }]
+      EOF
+    end
+
+    specify "containing arrays" do
+      pending 'Not implemented'
+
+      set_file_contents <<~EOF
+        list:
+          - - 1
+            - 2
+      EOF
+
+      vim.search 'list'
+      join
+
+      assert_file_contents <<~EOF
+        list: [[1, 2]]
+      EOF
+    end
+
+    specify "inside an array" do
+      pending 'Not implemented'
+
+      set_file_contents <<~EOF
+        list:
+          - - 1
+            - 2
+      EOF
+
+      vim.search '1'
+      join
+
+      assert_file_contents <<~EOF
+        list:
+          - [1, 2]
+      EOF
+    end
+
   end
 
   describe "maps" do
@@ -258,6 +311,24 @@ describe "yaml" do
           one: 1
 
         end: true
+      EOF
+    end
+
+    specify "inside an array" do
+      pending 'Not implemented'
+
+      set_file_contents <<~EOF
+        list:
+          - one: 1
+            two: 2
+      EOF
+
+      vim.search 'one:'
+      join
+
+      assert_file_contents <<~EOF
+        list:
+          - { one: 1, two: 2 }
       EOF
     end
   end

--- a/spec/plugin/yaml_spec.rb
+++ b/spec/plugin/yaml_spec.rb
@@ -109,6 +109,21 @@ describe "yaml" do
       EOF
     end
 
+    specify "splitting nested maps inside an array" do
+      set_file_contents <<~EOF
+        root: [{ one: { foo: bar } }]
+      EOF
+
+      vim.search 'root'
+      split
+
+      assert_file_contents <<~EOF
+        root:
+          - one: { foo: bar }
+      EOF
+    end
+
+
     specify "nested objects inside an array" do
       set_file_contents <<~EOF
         root:
@@ -492,5 +507,21 @@ describe "yaml" do
       EOF
     end
 
+    specify "containing nested maps (recursive)" do
+      pending 'Not implemented'
+
+      set_file_contents <<~EOF
+        map:
+          foo:
+            bar: 2
+      EOF
+
+      vim.search 'map'
+      join
+
+      assert_file_contents <<~EOF
+        map: { foo: { bar: 1 } }
+      EOF
+    end
   end
 end

--- a/spec/plugin/yaml_spec.rb
+++ b/spec/plugin/yaml_spec.rb
@@ -127,7 +127,7 @@ describe "yaml" do
 
     specify "list of simple objects" do
       set_file_contents <<~EOF
-        list: [{ prop: 1 }, { prop: 2 }]
+        list: [{ aprop: 1 }, { aProp: 2 }, { 'a:prop': 3 }, { a prop: 4 }]
       EOF
 
       vim.search 'list'
@@ -135,21 +135,23 @@ describe "yaml" do
 
       assert_file_contents <<~EOF
         list:
-          - prop: 1
-          - prop: 2
+          - aprop: 1
+          - aProp: 2
+          - 'a:prop': 3
+          - a prop: 4
       EOF
 
       vim.search 'list'
       join
 
       assert_file_contents <<~EOF
-        list: [{ prop: 1 }, { prop: 2 }]
+        list: [{ aprop: 1 }, { aProp: 2 }, { 'a:prop': 3 }, { a prop: 4 }]
       EOF
     end
 
     specify "containing mixed elements" do
       set_file_contents <<~EOF
-        list: [{ prop: 1 }, { a: 1, b: 2 }, "a: b"]
+        list: [{ prop: 1 }, { a: 1, b: 2 }, "a: b", { a value: 1, 'a:value': 2, aValue: 3 }]
       EOF
 
       vim.search 'list'
@@ -160,13 +162,14 @@ describe "yaml" do
           - prop: 1
           - { a: 1, b: 2 }
           - "a: b"
+          - { a value: 1, 'a:value': 2, aValue: 3 }
       EOF
 
       vim.search 'list'
       join
 
       assert_file_contents <<~EOF
-        list: [{ prop: 1 }, { a: 1, b: 2 }, "a: b"]
+        list: [{ prop: 1 }, { a: 1, b: 2 }, "a: b", { a value: 1, 'a:value': 2, aValue: 3 }]
       EOF
     end
 
@@ -283,6 +286,21 @@ describe "yaml" do
         root:
           one: { foo: bar }
           two: { three: ['four', 'five'], six: seven }
+      EOF
+    end
+
+    specify "complex keys" do
+      set_file_contents <<~EOF
+        map:
+          one value: 1
+          'my:key': 2
+      EOF
+
+      vim.search 'root'
+      join
+
+      assert_file_contents <<~EOF
+        map: { one value: 1, 'my:key': 2 }
       EOF
     end
 

--- a/spec/plugin/yaml_spec.rb
+++ b/spec/plugin/yaml_spec.rb
@@ -236,8 +236,6 @@ describe "yaml" do
     end
 
     specify "inside an array" do
-      pending 'Not implemented'
-
       set_file_contents <<~EOF
         list:
           - - 1
@@ -284,10 +282,7 @@ describe "yaml" do
       EOF
     end
 
-
     specify "join nested arrays" do
-      pending 'Not implemented'
-
       set_file_contents <<~EOF
         list:
           - - - 1

--- a/spec/plugin/yaml_spec.rb
+++ b/spec/plugin/yaml_spec.rb
@@ -432,6 +432,20 @@ describe "yaml" do
       EOF
     end
 
+    specify "with multiple spaces after key" do
+      set_file_contents <<~EOF
+        root:  { one: 1 }
+      EOF
+
+      vim.search 'root:'
+      split
+
+      assert_file_contents <<~EOF
+        root:
+          one: 1
+      EOF
+    end
+
     specify "complex keys" do
       set_file_contents <<~EOF
         map:


### PR DESCRIPTION
@AndrewRadev I'm sorry I kind of mixed a couple things together in this PR, let me know if you prefer this to be split up into multiple PRs.

I improved these cases for YAML:

- **Splitting arrays of strings containing colons**:
  ```yaml
  list:
    - 'a: b'
  ```
  <=>

  ```yaml
  list: ['a: b']
  ```

- **Splitting arrays of strings containing commas**:
  ```yaml
  list:
    - 'a, b'
  ```
  <=>

  ```yaml
  list: ['a, b']
  ```

- **Preserve trailing empty lines**

  ```yaml
  list_a:
    - 1
    - 2

  list_b: [1]
  ```
  <=>

  ```yaml
  list_a: [1, 2]

  list_b: [1]
  ```
- **Splitting and joining arrays containing objects**
  ```yaml
  list:
    - prop: 1
    - prop: 2
  ```
  <=>

  ```yaml
  list: [{ prop: 1 }, { prop: 2 }]
  ```

- **Fix map keys containing a colon**
  ```yaml
  list:
    - 'a:prop': 3
  ```
  <=>

  ```yaml
  list: [{ 'a:prop': 3 }]
  ```

- **Splitting and joining nested arrays**
  ```yaml
  list: [[[1, 2]]]
  ```
  <=>

  ```yaml
  list:
    - [[1, 2]]
  ```
  <=>

  ```yaml
  list:
    - - [1, 2]
  ```
  <=>

  ```yaml
  list:
    - - - 1
        - 2
  ```




