### PR TITLE
Add support for Elixir arrays

### DIFF
--- a/autoload/sj/elixir.vim
+++ b/autoload/sj/elixir.vim
@@ -54,7 +54,7 @@ function! sj#elixir#SplitArray()
 
   let items = sj#ParseJsonObjectBody(from + 1, to - 1)
 
-  if len(items) == 0
+  if len(items) == 0 || to - from < 2
     return 1
   endif
 

--- a/autoload/sj/elixir.vim
+++ b/autoload/sj/elixir.vim
@@ -39,3 +39,49 @@ function! sj#elixir#JoinDef()
   call sj#ReplaceLines(def_lineno, end_lineno, joined_line)
   return 1
 endfunction
+
+function! sj#elixir#SplitArray()
+  let [from, to] = sj#LocateBracesAroundCursor('[', ']', [
+        \ 'elixirInterpolationDelimiter',
+        \ 'elixirString',
+        \ 'elixirStringDelimiter',
+        \ 'elixirSigilDelimiter',
+        \ ])
+
+  if from < 0
+    return 0
+  endif
+
+  let items = sj#ParseJsonObjectBody(from + 1, to - 1)
+
+  " substitute [1, 2, | tail]
+  let items[-1] = substitute(items[-1], "\\(|[^>].*\\)", "\n\\1", "")
+
+  let body = "[\n" . join(items, ",\n") . "\n]"
+
+  call sj#ReplaceMotion('Va[', body)
+
+  return 1
+endfunction
+
+function! sj#elixir#JoinArray()
+  normal! $
+
+  if getline('.')[col('.') - 1] != '['
+    return 0
+  endif
+
+  let body = sj#Trim(sj#GetMotion('Vi['))
+  " remove trailing comma
+  let body = substitute(body, ',\ze\_s*$', '', '')
+
+  let items = split(body, ",\s*\n")
+
+  " join isolated | tail on the last line
+  let items[-1] = substitute(items[-1], "[[:space:]]*\\(|[^>].*\\)", " \\1", "")
+
+  let body = join(sj#TrimList(items), ', ')
+  call sj#ReplaceMotion('Va[', '['.body.']')
+
+  return 1
+endfunction

--- a/autoload/sj/elixir.vim
+++ b/autoload/sj/elixir.vim
@@ -54,6 +54,10 @@ function! sj#elixir#SplitArray()
 
   let items = sj#ParseJsonObjectBody(from + 1, to - 1)
 
+  if len(items) == 0
+    return 1
+  endif
+
   " substitute [1, 2, | tail]
   let items[-1] = substitute(items[-1], "\\(|[^>].*\\)", "\n\\1", "")
 
@@ -76,6 +80,10 @@ function! sj#elixir#JoinArray()
   let body = substitute(body, ',\ze\_s*$', '', '')
 
   let items = split(body, ",\s*\n")
+
+  if len(items) == 0
+    return 1
+  endif
 
   " join isolated | tail on the last line
   let items[-1] = substitute(items[-1], "[[:space:]]*\\(|[^>].*\\)", " \\1", "")

--- a/ftplugin/elixir/splitjoin.vim
+++ b/ftplugin/elixir/splitjoin.vim
@@ -1,7 +1,9 @@
 let b:splitjoin_split_callbacks = [
       \ 'sj#elixir#SplitDef',
+      \ 'sj#elixir#SplitArray',
       \ ]
 
 let b:splitjoin_join_callbacks = [
       \ 'sj#elixir#JoinDef',
+      \ 'sj#elixir#JoinArray',
       \ ]

--- a/spec/plugin/elixir_spec.rb
+++ b/spec/plugin/elixir_spec.rb
@@ -99,4 +99,48 @@ describe "elixir" do
       EOF
     end
   end
+
+  specify "arrays" do
+    set_file_contents <<~EOF
+      [a, b, c]
+    EOF
+
+    split
+
+    assert_file_contents <<~EOF
+      [
+        a,
+        b,
+        c
+      ]
+    EOF
+
+    vim.search('[')
+    join
+
+    assert_file_contents <<~EOF
+      [a, b, c]
+    EOF
+
+    set_file_contents <<~EOF
+      [a: 1, b: 2, c: %{a: 1, b: 2}]
+    EOF
+
+    split
+
+    assert_file_contents <<~EOF
+      [
+        a: 1,
+        b: 2,
+        c: %{a: 1, b: 2}
+      ]
+    EOF
+
+    vim.search('[')
+    join
+
+    assert_file_contents <<~EOF
+      [a: 1, b: 2, c: %{a: 1, b: 2}]
+    EOF
+  end
 end

--- a/spec/plugin/elixir_spec.rb
+++ b/spec/plugin/elixir_spec.rb
@@ -142,5 +142,23 @@ describe "elixir" do
     assert_file_contents <<~EOF
       [a: 1, b: 2, c: %{a: 1, b: 2}]
     EOF
+
+    set_file_contents <<~EOF
+      []
+    EOF
+
+    vim.search('[')
+    split
+
+    assert_file_contents <<~EOF
+      []
+    EOF
+
+    vim.search('[')
+    join
+
+    assert_file_contents <<~EOF
+      []
+    EOF
   end
 end


### PR DESCRIPTION
This PR adds support for array splitting and joining in Elixir.

Works with the following examples:

```
[a, b, c]

[
  a,
  b,
  c
]

[a, b, c | d]

[
  a,
  b,
  c 
  | d
]

[a: 1, b: 2, c: %{a: 1, b: 2}]

[
  a: 1,
  b: 2,
  c: %{a: 1, b: 2}
]

[a: 1, b: 2 | [c: %{d | e: 1}]]

[
  a: 1,
  b: 2 
  | [c: %{d | e: 1}]
]

[1, 2, 2 |> Kernel.+(1) | [4]]

[
  1,
  2,
  2 |> Kernel.+(1) 
  | [4]
]
```

I did manage to find an edge case where this doesn't work:

```
[a: 1, b: 2, c: %{d | e: 1}]

[
  a: 1,
  b: 2,
  c: %{d 
    | e: 1}
]
```

However, to handle this it's necessary to build a parser and given it's such an uncommon edge case (updating a map when declaring the last element of an array), I assumed it wouldn't be worth the effort.