### PR TITLE
add Json to list of supported languages

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ This currently works for various constructs in the following languages:
 - HTML (and HTML-like markup)
 - Handlebars
 - Javascript (within JSX, TSX, Vue.js templates as well)
+- JSON
 - Lua
 - PHP
 - Perl


### PR DESCRIPTION
Hey, just a small improvement . Before installing this plugin I checked a list of supported languages and it doesn't have a JSON (while YAML is in the list). Before creating an issue I found a closed [one](https://github.com/AndrewRadev/splitjoin.vim/issues/103) 
 and then I happily installed this extension. For people like me it would be great to see a JSON in the README . Thanks 