### PR TITLE
splitjoin_trailing_comma applies to perl arrays

### DIFF
--- a/autoload/sj/perl.vim
+++ b/autoload/sj/perl.vim
@@ -130,7 +130,11 @@ function! sj#perl#SplitSquareBracketedList()
   endif
 
   let items = sj#ParseJsonObjectBody(from + 1, to - 1)
-  let body  = "[\n".join(items, ",\n")."\n]"
+  let body  = "[\n".join(items, ",\n")
+  if sj#settings#Read('trailing_comma')
+      let body .= ","
+  endif
+  let body .= "\n]"
   call sj#ReplaceMotion('Va[', body)
 
   return 1
@@ -143,7 +147,11 @@ function! sj#perl#SplitRoundBracketedList()
   endif
 
   let items = sj#ParseJsonObjectBody(from + 1, to - 1)
-  let body  = "(\n".join(items, ",\n")."\n)"
+  let body  = "(\n".join(items, ",\n")
+  if sj#settings#Read('trailing_comma')
+      let body .= ","
+  endif
+  let body .= "\n)"
   call sj#ReplaceMotion('Va(', body)
 
   return 1

--- a/doc/splitjoin.txt
+++ b/doc/splitjoin.txt
@@ -641,9 +641,9 @@ Hashes ~
 <
 Lists ~
 >
-    my @var = ['one', 'two', 'three'];
+    my $var = ['one', 'two', 'three'];
 
-    my @var = [
+    my $var = [
       'one',
       'two',
       'three'

--- a/spec/plugin/perl_spec.rb
+++ b/spec/plugin/perl_spec.rb
@@ -8,6 +8,10 @@ describe "perl" do
     vim.set(:shiftwidth, 2)
   end
 
+  after :each do
+    vim.command('silent! unlet g:splitjoin_trailing_comma')
+  end
+
   after :all do
     # The perl filetype messes with iskeyword...
     vim.command('set iskeyword-=:')
@@ -92,6 +96,25 @@ describe "perl" do
     assert_file_contents "my @var = ['one', 'two', 'three'];"
   end
 
+  specify "square-bracketed list, trailing comma" do
+    vim.command('let g:splitjoin_trailing_comma = 1')
+    set_file_contents "my @var = ['one', 'two', 'three'];"
+
+    split
+
+    assert_file_contents <<~EOF
+      my @var = [
+        'one',
+        'two',
+        'three',
+      ];
+    EOF
+
+    join
+
+    assert_file_contents "my @var = ['one', 'two', 'three'];"
+  end
+
   specify "round-bracketed list" do
     set_file_contents "my @var = ('one', 'two', 'three');"
 
@@ -102,6 +125,25 @@ describe "perl" do
         'one',
         'two',
         'three'
+      );
+    EOF
+
+    join
+
+    assert_file_contents "my @var = ('one', 'two', 'three');"
+  end
+
+  specify "round-bracketed list, trailing comma" do
+    vim.command('let g:splitjoin_trailing_comma = 1')
+    set_file_contents "my @var = ('one', 'two', 'three');"
+
+    split
+
+    assert_file_contents <<~EOF
+      my @var = (
+        'one',
+        'two',
+        'three',
       );
     EOF
 


### PR DESCRIPTION
I noticed that this setting wasn't being used for perl.