### PR TITLE
refactor: decrease startup time

### DIFF
--- a/plugin/splitjoin.vim
+++ b/plugin/splitjoin.vim
@@ -9,30 +9,6 @@ set cpo&vim
 " Defaults:
 " =========
 
-call sj#settings#SetDefault('quiet',                    0)
-call sj#settings#SetDefault('disabled_split_callbacks', [])
-call sj#settings#SetDefault('disabled_join_callbacks',  [])
-
-call sj#settings#SetDefault('normalize_whitespace',                    1)
-call sj#settings#SetDefault('trailing_comma',                          0)
-call sj#settings#SetDefault('align',                                   0)
-call sj#settings#SetDefault('curly_brace_padding',                     1)
-call sj#settings#SetDefault('ruby_curly_braces',                       1)
-call sj#settings#SetDefault('ruby_heredoc_type',                       '<<~')
-call sj#settings#SetDefault('ruby_trailing_comma',                     0)
-call sj#settings#SetDefault('ruby_hanging_args',                       1)
-call sj#settings#SetDefault('ruby_do_block_split',                     1)
-call sj#settings#SetDefault('ruby_options_as_arguments',               0)
-call sj#settings#SetDefault('coffee_suffix_if_clause',                 1)
-call sj#settings#SetDefault('perl_brace_on_same_line',                 1)
-call sj#settings#SetDefault('php_method_chain_full',                   0)
-call sj#settings#SetDefault('python_brackets_on_separate_lines',       0)
-call sj#settings#SetDefault('handlebars_closing_bracket_on_same_line', 0)
-call sj#settings#SetDefault('handlebars_hanging_arguments',            0)
-call sj#settings#SetDefault('html_attribute_bracket_on_new_line',      0)
-call sj#settings#SetDefault('java_argument_split_first_newline',       0)
-call sj#settings#SetDefault('java_argument_split_last_newline',        0)
-
 if !exists('g:splitjoin_join_mapping')
   let g:splitjoin_join_mapping = 'gJ'
 endif
@@ -44,116 +20,22 @@ endif
 " Public Interface:
 " =================
 
-command! SplitjoinSplit call s:Split()
-command! SplitjoinJoin  call s:Join()
+command! SplitjoinSplit call sj#Split()
+command! SplitjoinJoin  call sj#Join()
 
-nnoremap <silent> <plug>SplitjoinSplit :<c-u>call <SID>Split()<cr>
-nnoremap <silent> <plug>SplitjoinJoin  :<c-u>call <SID>Join()<cr>
+nnoremap <silent> <plug>SplitjoinSplit :<c-u>call sj#Split()<cr>
+nnoremap <silent> <plug>SplitjoinJoin  :<c-u>call sj#Join()<cr>
 
 if g:splitjoin_join_mapping != ''
-  exe 'nnoremap <silent> '.g:splitjoin_join_mapping.' :<c-u>call <SID>Mapping(g:splitjoin_join_mapping, "<SID>Join")<cr>'
+  exe 'nnoremap <silent> '.g:splitjoin_join_mapping.' :<c-u>call <SID>Mapping(g:splitjoin_join_mapping, "sj#Join")<cr>'
 endif
 
 if g:splitjoin_split_mapping != ''
-  exe 'nnoremap <silent> '.g:splitjoin_split_mapping.' :<c-u>call <SID>Mapping(g:splitjoin_split_mapping, "<SID>Split")<cr>'
+  exe 'nnoremap <silent> '.g:splitjoin_split_mapping.' :<c-u>call <SID>Mapping(g:splitjoin_split_mapping, "sj#Split")<cr>'
 endif
 
 " Internal Functions:
 " ===================
-
-function! s:Split()
-  if !exists('b:splitjoin_split_callbacks')
-    return
-  end
-
-  " expand any folds under the cursor, or we might replace the wrong area
-  silent! foldopen
-
-  let disabled_callbacks = sj#settings#Read('disabled_split_callbacks')
-
-  let saved_view = winsaveview()
-  let saved_whichwrap = &whichwrap
-  set whichwrap-=l
-
-  if !sj#settings#Read('quiet') | echo "Splitjoin: Working..." | endif
-  for callback in b:splitjoin_split_callbacks
-    if index(disabled_callbacks, callback) >= 0
-      continue
-    endif
-
-    try
-      call sj#PushCursor()
-
-      if call(callback, [])
-        silent! call repeat#set("\<plug>SplitjoinSplit")
-        let &whichwrap = saved_whichwrap
-        if !sj#settings#Read('quiet')
-          " clear progress message
-          redraw | echo ""
-        endif
-        return 1
-      endif
-
-    finally
-      call sj#PopCursor()
-    endtry
-  endfor
-
-  call winrestview(saved_view)
-  let &whichwrap = saved_whichwrap
-  if !sj#settings#Read('quiet')
-    " clear progress message
-    redraw | echo ""
-  endif
-  return 0
-endfunction
-
-function! s:Join()
-  if !exists('b:splitjoin_join_callbacks')
-    return
-  end
-
-  " expand any folds under the cursor, or we might replace the wrong area
-  silent! foldopen
-
-  let disabled_callbacks = sj#settings#Read('disabled_join_callbacks')
-
-  let saved_view = winsaveview()
-  let saved_whichwrap = &whichwrap
-  set whichwrap-=l
-
-  if !sj#settings#Read('quiet') | echo "Splitjoin: Working..." | endif
-  for callback in b:splitjoin_join_callbacks
-    if index(disabled_callbacks, callback) >= 0
-      continue
-    endif
-
-    try
-      call sj#PushCursor()
-
-      if call(callback, [])
-        silent! call repeat#set("\<plug>SplitjoinJoin")
-        let &whichwrap = saved_whichwrap
-        if !sj#settings#Read('quiet')
-          " clear progress message
-          redraw | echo ""
-        endif
-        return 1
-      endif
-
-    finally
-      call sj#PopCursor()
-    endtry
-  endfor
-
-  call winrestview(saved_view)
-  let &whichwrap = saved_whichwrap
-  if !sj#settings#Read('quiet')
-    " clear progress message
-    redraw | echo ""
-  endif
-  return 0
-endfunction
 
 " Used to create a mapping for the given a:function that falls back to the
 " built-in key sequence (a:mapping) if the function returns 0, meaning it


### PR DESCRIPTION
By moving main functions and default options in autoload script, so that
options are evaluated on first command usage.

I got one failed test, not sure if it's important:
```Failures:

  1) ruby cases aligns thens in supercompact cases
     Failure/Error: expect(IO.read(filename).strip).to eq(string.strip)

       expected: "case\nwhen cond1      then stuff1\nwhen condition2 then stuff2\nelse stuff3\nend"
            got: "case\nwhen cond1 then stuff1\nwhen condition2 then stuff2\nelse stuff3\nend"

       (compared using ==)

       Diff:
       @@ -1,5 +1,5 @@
        case
       -when cond1      then stuff1
       +when cond1 then stuff1
        when condition2 then stuff2
        else stuff3
        end

     # ./spec/support/vim.rb:24:in `assert_file_contents'
     # ./spec/plugin/ruby_spec.rb:477:in `block (3 levels) in <top (required)>'
     # ./vendor/bundle/ruby/2.7.0/gems/vimrunner-0.3.4/lib/vimrunner/rspec.rb:53:in `block (4 levels)
in <top (required)>'
     # ./vendor/bundle/ruby/2.7.0/gems/vimrunner-0.3.4/lib/vimrunner/rspec.rb:51:in `chdir'
     # ./vendor/bundle/ruby/2.7.0/gems/vimrunner-0.3.4/lib/vimrunner/rspec.rb:51:in `block (3 levels)
in <top (required)>'
     # ./vendor/bundle/ruby/2.7.0/gems/vimrunner-0.3.4/lib/vimrunner/rspec.rb:50:in `block (2 levels)
in <top (required)>'

Finished in 2 minutes 29.4 seconds (files took 0.15735 seconds to load)
351 examples, 1 failure

Failed examples:

rspec ./spec/plugin/ruby_spec.rb:462 # ruby cases aligns thens in supercompact cases

```