### PR TITLE
Faster startup

### DIFF
--- a/autoload/sj.vim
+++ b/autoload/sj.vim
@@ -1,5 +1,107 @@
 " vim: foldmethod=marker
 
+" Main entry points {{{1
+"
+" The two main functions that loop through callbacks and execute them.
+"
+" function! sj#Split() {{{2
+"
+function! sj#Split()
+  if !exists('b:splitjoin_split_callbacks')
+    return
+  end
+
+  " expand any folds under the cursor, or we might replace the wrong area
+  silent! foldopen
+
+  let disabled_callbacks = sj#settings#Read('disabled_split_callbacks')
+
+  let saved_view = winsaveview()
+  let saved_whichwrap = &whichwrap
+  set whichwrap-=l
+
+  if !sj#settings#Read('quiet') | echo "Splitjoin: Working..." | endif
+  for callback in b:splitjoin_split_callbacks
+    if index(disabled_callbacks, callback) >= 0
+      continue
+    endif
+
+    try
+      call sj#PushCursor()
+
+      if call(callback, [])
+        silent! call repeat#set("\<plug>SplitjoinSplit")
+        let &whichwrap = saved_whichwrap
+        if !sj#settings#Read('quiet')
+          " clear progress message
+          redraw | echo ""
+        endif
+        return 1
+      endif
+
+    finally
+      call sj#PopCursor()
+    endtry
+  endfor
+
+  call winrestview(saved_view)
+  let &whichwrap = saved_whichwrap
+  if !sj#settings#Read('quiet')
+    " clear progress message
+    redraw | echo ""
+  endif
+  return 0
+endfunction
+
+" function! sj#Join() {{{2
+"
+function! sj#Join()
+  if !exists('b:splitjoin_join_callbacks')
+    return
+  end
+
+  " expand any folds under the cursor, or we might replace the wrong area
+  silent! foldopen
+
+  let disabled_callbacks = sj#settings#Read('disabled_join_callbacks')
+
+  let saved_view = winsaveview()
+  let saved_whichwrap = &whichwrap
+  set whichwrap-=l
+
+  if !sj#settings#Read('quiet') | echo "Splitjoin: Working..." | endif
+  for callback in b:splitjoin_join_callbacks
+    if index(disabled_callbacks, callback) >= 0
+      continue
+    endif
+
+    try
+      call sj#PushCursor()
+
+      if call(callback, [])
+        silent! call repeat#set("\<plug>SplitjoinJoin")
+        let &whichwrap = saved_whichwrap
+        if !sj#settings#Read('quiet')
+          " clear progress message
+          redraw | echo ""
+        endif
+        return 1
+      endif
+
+    finally
+      call sj#PopCursor()
+    endtry
+  endfor
+
+  call winrestview(saved_view)
+  let &whichwrap = saved_whichwrap
+  if !sj#settings#Read('quiet')
+    " clear progress message
+    redraw | echo ""
+  endif
+  return 0
+endfunction
+
 " Cursor stack manipulation {{{1
 "
 " In order to make the pattern of saving the cursor and restoring it

--- a/autoload/sj/settings.vim
+++ b/autoload/sj/settings.vim
@@ -12,7 +12,7 @@
 "   - g:splitjoin_option_bar
 "
 " and return the first one that exists. If none exist, it reads the default
-" value, if one is set in `g:splitjoin_defaults`
+" value, if one is set in `g:splitjoin_default_settings`
 "
 function! sj#settings#Read(...)
   let options = a:000
@@ -28,8 +28,8 @@ function! sj#settings#Read(...)
   endfor
 
   for option in options
-    if has_key(g:splitjoin_defaults, option)
-      return g:splitjoin_defaults[option]
+    if has_key(g:splitjoin_default_settings, option)
+      return g:splitjoin_default_settings[option]
     endif
   endfor
 

--- a/autoload/sj/settings.vim
+++ b/autoload/sj/settings.vim
@@ -1,5 +1,3 @@
-let s:defaults = {}
-
 " This function accepts multiple option names and returns the value of the
 " first one that is set. It respects buffer-local values before global ones,
 " so:
@@ -14,7 +12,7 @@ let s:defaults = {}
 "   - g:splitjoin_option_bar
 "
 " and return the first one that exists. If none exist, it reads the default
-" value, if one is set.
+" value, if one is set in `g:splitjoin_defaults`
 "
 function! sj#settings#Read(...)
   let options = a:000
@@ -30,14 +28,10 @@ function! sj#settings#Read(...)
   endfor
 
   for option in options
-    if has_key(s:defaults, option)
-      return s:defaults[option]
+    if has_key(g:splitjoin_defaults, option)
+      return g:splitjoin_defaults[option]
     endif
   endfor
 
   return 0
-endfunction
-
-function! sj#settings#SetDefault(option, value)
-  let s:defaults[a:option] = a:value
 endfunction

--- a/plugin/splitjoin.vim
+++ b/plugin/splitjoin.vim
@@ -9,29 +9,31 @@ set cpo&vim
 " Defaults:
 " =========
 
-call sj#settings#SetDefault('quiet',                    0)
-call sj#settings#SetDefault('disabled_split_callbacks', [])
-call sj#settings#SetDefault('disabled_join_callbacks',  [])
-
-call sj#settings#SetDefault('normalize_whitespace',                    1)
-call sj#settings#SetDefault('trailing_comma',                          0)
-call sj#settings#SetDefault('align',                                   0)
-call sj#settings#SetDefault('curly_brace_padding',                     1)
-call sj#settings#SetDefault('ruby_curly_braces',                       1)
-call sj#settings#SetDefault('ruby_heredoc_type',                       '<<~')
-call sj#settings#SetDefault('ruby_trailing_comma',                     0)
-call sj#settings#SetDefault('ruby_hanging_args',                       1)
-call sj#settings#SetDefault('ruby_do_block_split',                     1)
-call sj#settings#SetDefault('ruby_options_as_arguments',               0)
-call sj#settings#SetDefault('coffee_suffix_if_clause',                 1)
-call sj#settings#SetDefault('perl_brace_on_same_line',                 1)
-call sj#settings#SetDefault('php_method_chain_full',                   0)
-call sj#settings#SetDefault('python_brackets_on_separate_lines',       0)
-call sj#settings#SetDefault('handlebars_closing_bracket_on_same_line', 0)
-call sj#settings#SetDefault('handlebars_hanging_arguments',            0)
-call sj#settings#SetDefault('html_attribute_bracket_on_new_line',      0)
-call sj#settings#SetDefault('java_argument_split_first_newline',       0)
-call sj#settings#SetDefault('java_argument_split_last_newline',        0)
+let g:splitjoin_defaults = {
+      \ 'quiet':                    0,
+      \ 'disabled_split_callbacks': [],
+      \ 'disabled_join_callbacks':  [],
+      \
+      \ 'normalize_whitespace':                    1,
+      \ 'trailing_comma':                          0,
+      \ 'align':                                   0,
+      \ 'curly_brace_padding':                     1,
+      \ 'ruby_curly_braces':                       1,
+      \ 'ruby_heredoc_type':                       '<<~',
+      \ 'ruby_trailing_comma':                     0,
+      \ 'ruby_hanging_args':                       1,
+      \ 'ruby_do_block_split':                     1,
+      \ 'ruby_options_as_arguments':               0,
+      \ 'coffee_suffix_if_clause':                 1,
+      \ 'perl_brace_on_same_line':                 1,
+      \ 'php_method_chain_full':                   0,
+      \ 'python_brackets_on_separate_lines':       0,
+      \ 'handlebars_closing_bracket_on_same_line': 0,
+      \ 'handlebars_hanging_arguments':            0,
+      \ 'html_attribute_bracket_on_new_line':      0,
+      \ 'java_argument_split_first_newline':       0,
+      \ 'java_argument_split_last_newline':        0,
+      \ }
 
 if !exists('g:splitjoin_join_mapping')
   let g:splitjoin_join_mapping = 'gJ'
@@ -44,116 +46,22 @@ endif
 " Public Interface:
 " =================
 
-command! SplitjoinSplit call s:Split()
-command! SplitjoinJoin  call s:Join()
+command! SplitjoinSplit call sj#Split()
+command! SplitjoinJoin  call sj#Join()
 
-nnoremap <silent> <plug>SplitjoinSplit :<c-u>call <SID>Split()<cr>
-nnoremap <silent> <plug>SplitjoinJoin  :<c-u>call <SID>Join()<cr>
+nnoremap <silent> <plug>SplitjoinSplit :<c-u>call sj#Split()<cr>
+nnoremap <silent> <plug>SplitjoinJoin  :<c-u>call sj#Join()<cr>
 
 if g:splitjoin_join_mapping != ''
-  exe 'nnoremap <silent> '.g:splitjoin_join_mapping.' :<c-u>call <SID>Mapping(g:splitjoin_join_mapping, "<SID>Join")<cr>'
+  exe 'nnoremap <silent> '.g:splitjoin_join_mapping.' :<c-u>call <SID>Mapping(g:splitjoin_join_mapping, "sj#Join")<cr>'
 endif
 
 if g:splitjoin_split_mapping != ''
-  exe 'nnoremap <silent> '.g:splitjoin_split_mapping.' :<c-u>call <SID>Mapping(g:splitjoin_split_mapping, "<SID>Split")<cr>'
+  exe 'nnoremap <silent> '.g:splitjoin_split_mapping.' :<c-u>call <SID>Mapping(g:splitjoin_split_mapping, "sj#Split")<cr>'
 endif
 
 " Internal Functions:
 " ===================
-
-function! s:Split()
-  if !exists('b:splitjoin_split_callbacks')
-    return
-  end
-
-  " expand any folds under the cursor, or we might replace the wrong area
-  silent! foldopen
-
-  let disabled_callbacks = sj#settings#Read('disabled_split_callbacks')
-
-  let saved_view = winsaveview()
-  let saved_whichwrap = &whichwrap
-  set whichwrap-=l
-
-  if !sj#settings#Read('quiet') | echo "Splitjoin: Working..." | endif
-  for callback in b:splitjoin_split_callbacks
-    if index(disabled_callbacks, callback) >= 0
-      continue
-    endif
-
-    try
-      call sj#PushCursor()
-
-      if call(callback, [])
-        silent! call repeat#set("\<plug>SplitjoinSplit")
-        let &whichwrap = saved_whichwrap
-        if !sj#settings#Read('quiet')
-          " clear progress message
-          redraw | echo ""
-        endif
-        return 1
-      endif
-
-    finally
-      call sj#PopCursor()
-    endtry
-  endfor
-
-  call winrestview(saved_view)
-  let &whichwrap = saved_whichwrap
-  if !sj#settings#Read('quiet')
-    " clear progress message
-    redraw | echo ""
-  endif
-  return 0
-endfunction
-
-function! s:Join()
-  if !exists('b:splitjoin_join_callbacks')
-    return
-  end
-
-  " expand any folds under the cursor, or we might replace the wrong area
-  silent! foldopen
-
-  let disabled_callbacks = sj#settings#Read('disabled_join_callbacks')
-
-  let saved_view = winsaveview()
-  let saved_whichwrap = &whichwrap
-  set whichwrap-=l
-
-  if !sj#settings#Read('quiet') | echo "Splitjoin: Working..." | endif
-  for callback in b:splitjoin_join_callbacks
-    if index(disabled_callbacks, callback) >= 0
-      continue
-    endif
-
-    try
-      call sj#PushCursor()
-
-      if call(callback, [])
-        silent! call repeat#set("\<plug>SplitjoinJoin")
-        let &whichwrap = saved_whichwrap
-        if !sj#settings#Read('quiet')
-          " clear progress message
-          redraw | echo ""
-        endif
-        return 1
-      endif
-
-    finally
-      call sj#PopCursor()
-    endtry
-  endfor
-
-  call winrestview(saved_view)
-  let &whichwrap = saved_whichwrap
-  if !sj#settings#Read('quiet')
-    " clear progress message
-    redraw | echo ""
-  endif
-  return 0
-endfunction
 
 " Used to create a mapping for the given a:function that falls back to the
 " built-in key sequence (a:mapping) if the function returns 0, meaning it

--- a/plugin/splitjoin.vim
+++ b/plugin/splitjoin.vim
@@ -9,7 +9,7 @@ set cpo&vim
 " Defaults:
 " =========
 
-let g:splitjoin_defaults = {
+let g:splitjoin_default_settings = {
       \ 'quiet':                    0,
       \ 'disabled_split_callbacks': [],
       \ 'disabled_join_callbacks':  [],


### PR DESCRIPTION
The slowest part of `plugin/splitjoin.vim` is defining the setting defaults (though it's still pretty fast). We can make this faster by just defining the dict directly.

Moving the main entry points out of the plugin directory is a very, very minor improvement, if any. But it's a good chunk of code that has always sat a bit weirdly in the plugin file, so it doesn't hurt to move it to autoload, too.