### PR TITLE
split ruby blocks correctly when ; is inside string literal

### DIFF
--- a/autoload/sj/ruby.vim
+++ b/autoload/sj/ruby.vim
@@ -366,7 +366,6 @@ function! sj#ruby#SplitBlock()
 
   call sj#ReplaceMotion('Va{', replacement)
 
-  call search(replacement, 'cW')
   normal! j0
   while sj#SearchSkip(';', sj#SkipSyntax(['rubyString']), 'W', line('.')) > 0
     call execute("normal! r\<cr>") 

--- a/autoload/sj/ruby.vim
+++ b/autoload/sj/ruby.vim
@@ -359,7 +359,15 @@ function! sj#ruby#SplitBlock()
     let multiline_block = ' '.multiline_block
   endif
 
-  let body = join(split(body, '\s*;\s*'), "\n")
+  " match ; if there isn't a (') before it
+  let quotation_not_before = '((\''.*)@<!(\s*;\s*))'
+  " match ; if there isn't a (') after it
+  let quotation_not_after  = '((\s*;\s*)(.*\'')@!)'
+  " match ; if there isn't a (') before it or if there isn't a (') after it
+  let delimiter = '\v'.quotation_not_before.'|'.quotation_not_after
+
+  let body = join(split(body, delimiter), "\n")
+  
   let replacement = substitute(body, '^'.pattern.'$', multiline_block, '')
   " remove leftover whitespace
   let replacement = substitute(replacement, '\s*\n', '\n', 'g')

--- a/autoload/sj/ruby.vim
+++ b/autoload/sj/ruby.vim
@@ -366,7 +366,7 @@ function! sj#ruby#SplitBlock()
 
   call sj#ReplaceMotion('Va{', replacement)
 
-  call search(replacement, 'cw')
+  call search(replacement, 'cW')
   normal! j0
   while sj#SearchSkip(';', sj#SkipSyntax(['rubyString']), 'W', line('.')) > 0
     call execute("normal! r\<cr>") 

--- a/autoload/sj/ruby.vim
+++ b/autoload/sj/ruby.vim
@@ -358,21 +358,19 @@ function! sj#ruby#SplitBlock()
   if search('\S\%#', 'Wbn')
     let multiline_block = ' '.multiline_block
   endif
-
-  " match ; if there isn't a (') before it
-  let quotation_not_before = '((\''.*)@<!(\s*;\s*))'
-  " match ; if there isn't a (') after it
-  let quotation_not_after  = '((\s*;\s*)(.*\'')@!)'
-  " match ; if there isn't a (') before it or if there isn't a (') after it
-  let delimiter = '\v'.quotation_not_before.'|'.quotation_not_after
-
-  let body = join(split(body, delimiter), "\n")
   
   let replacement = substitute(body, '^'.pattern.'$', multiline_block, '')
+
   " remove leftover whitespace
   let replacement = substitute(replacement, '\s*\n', '\n', 'g')
 
   call sj#ReplaceMotion('Va{', replacement)
+
+  call search(replacement, 'cw')
+  normal! j0
+  while sj#SearchSkip(';', sj#SkipSyntax(['rubyString']), 'W', line('.')) > 0
+    call execute("normal! r\<cr>") 
+  endwhile
 
   return 1
 endfunction

--- a/spec/plugin/ruby_spec.rb
+++ b/spec/plugin/ruby_spec.rb
@@ -987,7 +987,7 @@ describe "ruby" do
       EOF
     end
 
-    it "doesn't get confused when ; is in a string literal when splitting" do
+    it "doesn't get confused when ; is in a string literal(single quotes) when splitting" do
       set_file_contents <<~EOF
         foo { example1; 'some string ; literal' }
       EOF
@@ -999,6 +999,38 @@ describe "ruby" do
         foo do
           example1
           'some string ; literal'
+        end
+      EOF
+    end
+
+    it "doesn't get confused when ; is in a string literal(double quotes) when splitting" do
+      set_file_contents <<~EOF
+        foo { example1; "some string ; literal" }
+      EOF
+
+      vim.search 'example1;'
+      split
+
+      assert_file_contents <<~EOF
+        foo do
+          example1
+          "some string ; literal"
+        end
+      EOF
+    end
+
+    it "doesn't get confused when ; is in a string literal(percent strings) when splitting" do
+      set_file_contents <<~EOF
+        foo { example1; %(some string ; literal) }
+      EOF
+
+      vim.search 'example1;'
+      split
+
+      assert_file_contents <<~EOF
+        foo do
+          example1
+          %(some string ; literal)
         end
       EOF
     end

--- a/spec/plugin/ruby_spec.rb
+++ b/spec/plugin/ruby_spec.rb
@@ -955,6 +955,54 @@ describe "ruby" do
       EOF
     end
 
+    it "doesn't get confused by ; when joining" do
+      set_file_contents <<~EOF
+        foo do
+          example1
+          example2
+        end
+      EOF
+
+      vim.search 'do'
+      join
+
+      assert_file_contents <<~EOF
+        foo { example1; example2 }
+      EOF
+    end
+
+    it "doesn't get confused by ; when splitting" do
+      set_file_contents <<~EOF
+        foo { example1; example2 }
+      EOF
+
+      vim.search 'example1;'
+      split
+
+      assert_file_contents <<~EOF
+        foo do
+          example1
+          example2
+        end
+      EOF
+    end
+
+    it "doesn't get confused when ; is in a string literal when splitting" do
+      set_file_contents <<~EOF
+        foo { example1; 'some string ; literal' }
+      EOF
+
+      vim.search 'example1;'
+      split
+
+      assert_file_contents <<~EOF
+        foo do
+          example1
+          'some string ; literal'
+        end
+      EOF
+    end
+
     it "migrates inline comments when joining" do
       set_file_contents <<~EOF
         foo do


### PR DESCRIPTION
I was in the intro to Vim course in FMI when this bug was mentioned.
Decided this would be fun way to start my vimscript journey. 

I'm not familiar with Ruby so I'm not sure if this handles all the edge cases. 

The regex might be kind of overkill but I couldn't really find an easier alternative
to match only those ';' that are not surrounded by quotes.

Checking if ";" is NOT surrounded by quotation marks
 <=> 
NO quotation mark on its left   OR    NO quotation mark on its right 

Would love some feedback!