### PR TITLE
Fix joining single line Ruby methods without arguments

### DIFF
--- a/autoload/sj/ruby.vim
+++ b/autoload/sj/ruby.vim
@@ -1113,7 +1113,7 @@ endfunction
 
 function! sj#ruby#JoinOnelineDef()
   " adapted from vim-ruby
-  if search('\<def\s\+\%(\k\+\.\)\=\k\+[!?]\=\%((.*)\)\s*\%(#.*\)\=$', 'Wbc', line('.')) <= 0
+  if search('\<def\s\+\%(\k\+\.\)\=\k\+[!?]\=\s*\%((.*)\)\=\s*\%(#.*\)\=$', 'Wbc', line('.')) <= 0
     return 0
   endif
 

--- a/spec/plugin/ruby_spec.rb
+++ b/spec/plugin/ruby_spec.rb
@@ -1901,5 +1901,47 @@ describe "ruby" do
         def foo(one, two) = bar
       EOF
     end
+
+    specify "with the cursor on a definition without arguments" do
+      set_file_contents <<~EOF
+        def foo = bar
+      EOF
+
+      vim.search 'def'
+      split
+
+      assert_file_contents <<~EOF
+        def foo
+          bar
+        end
+      EOF
+
+      join
+
+      assert_file_contents <<~EOF
+        def foo = bar
+      EOF
+    end
+
+    specify "with the cursor on a definition arguments defaults" do
+      set_file_contents <<~EOF
+        def self.foo(bar = quux(42), ...) = bar
+      EOF
+
+      vim.search 'def'
+      split
+
+      assert_file_contents <<~EOF
+        def self.foo(bar = quux(42), ...)
+          bar
+        end
+      EOF
+
+      join
+
+      assert_file_contents <<~EOF
+        def self.foo(bar = quux(42), ...) = bar
+      EOF
+    end
   end
 end


### PR DESCRIPTION
Joining single-line Ruby method _without_ arguments into an endless method definition was not working as the regexp pattern expected the `def` always to accept parenthesized arguments.

Example:

```ruby
def foo()
  bar
end

```

Would be joined to:

```ruby
def foo() = bar
```

However, the following, which is the idiomatic way to write Ruby methods without arguments, would not:

```ruby
def foo
  bar
end
```